### PR TITLE
Rename some labeling concepts to be more clear and consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,19 @@ codebase:
 
 ```go
 c := codebase.LocalCodebase{}
-matches := labeling.ApplyAllRules(c)
-// matches: map of labels like "deps:node" to a Match structure containing more details
+labels := labeling.ApplyAllRules(c)
+// labels: map of keys like "deps:node" to a Label structure containing more details
 ```
 
 Rules for different stacks can be found in the [internal](labeling/internal) directory.
 
 ### Generating jobs for a given set of labels
 
-The [generation package](generation) takes a set of label matches and produces CI jobs for them,
+The [generation package](generation) takes a set of labels and produces CI jobs for them,
 and then assembles them into a config:
 
 ```go
-config := generation.GenerateConfig(matches)
+config := generation.GenerateConfig(labels)
 // config: data structure that represents a CircleCI config with workflows, jobs, orbs, etc.
 ```
 
@@ -48,10 +48,10 @@ Not all possible configs can be represented, only the ones needed for inference.
 
 Adding support for a new stack consists of three parts:
 
-1. Defining [labels](labeling/labels/labels.go) to identify the stack and its variants. Add
-   `"deps:..."` labels for dependency management, `"test:..."` labels for test runners, and
-   `"build:..."` labels for build systems (if they are different).
-2. Implementing rules that tag codebases with the above labels in the
+1. Define [label keys](labeling/labels/labels.go) to identify the stack and its variants. Add
+   `"deps:..."` keys for dependency management, `"test:..."` keys for test runners, and
+   `"build:..."` keys for build systems (if they are different).
+2. Implementing rules that label codebases with the above keys in the
    [labeling/internal directory](labeling/internal). Create a new file for each language.
    Then add those rules to the [`ApplyAllRules` function](labeling/labeling.go).
 3. Implement a function that given those rules generates jobs in the

--- a/generation/generation.go
+++ b/generation/generation.go
@@ -6,9 +6,9 @@ import (
 	"github.com/CircleCI-Public/circleci-config/labeling/labels"
 )
 
-func GenerateConfig(matches labels.MatchSet) config.Config {
+func GenerateConfig(labels labels.LabelSet) config.Config {
 	var generatedJobs []*internal.Job
-	generatedJobs = append(generatedJobs, internal.GenerateNodeJobs(matches)...)
-	generatedJobs = append(generatedJobs, internal.GenerateGoJobs(matches)...)
-	return internal.BuildConfig(matches, generatedJobs)
+	generatedJobs = append(generatedJobs, internal.GenerateNodeJobs(labels)...)
+	generatedJobs = append(generatedJobs, internal.GenerateGoJobs(labels)...)
+	return internal.BuildConfig(labels, generatedJobs)
 }

--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -34,21 +34,21 @@ func testEncode(t *testing.T, node config.Node, expected string) {
 func TestGenerateConfig(t *testing.T) {
 	tests := []struct {
 		testName string
-		matches  labels.MatchSet
+		labels   labels.LabelSet
 		expected string
 	}{
 		{
 			testName: "node and go codebases in subdirs",
-			matches: labels.MatchSet{
-				labels.DepsNode: labels.Match{
-					Label:     labels.DepsNode,
+			labels: labels.LabelSet{
+				labels.DepsNode: labels.Label{
+					Key:       labels.DepsNode,
 					Valid:     true,
-					MatchData: labels.MatchData{BasePath: "node-dir"},
+					LabelData: labels.LabelData{BasePath: "node-dir"},
 				},
-				labels.DepsGo: labels.Match{
-					Label:     labels.DepsGo,
+				labels.DepsGo: labels.Label{
+					Key:       labels.DepsGo,
 					Valid:     true,
-					MatchData: labels.MatchData{BasePath: "go-dir"},
+					LabelData: labels.LabelData{BasePath: "go-dir"},
 				}},
 			expected: "# This config was automatically generated from your source code\n" +
 				"# Stacks detected: deps:go:go-dir,deps:node:node-dir\n" +
@@ -102,7 +102,7 @@ func TestGenerateConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {
-			gotConfig := GenerateConfig(tt.matches)
+			gotConfig := GenerateConfig(tt.labels)
 			testEncode(t, gotConfig, tt.expected)
 		})
 	}
@@ -112,7 +112,7 @@ func TestDogfood(t *testing.T) {
 	expectedConfig := "# This config was automatically generated from your source code\n# Stacks detected: deps:go:.\nversion: 2.1\njobs:\n  test-go:\n    # Install go modules, run go vet and tests\n    docker:\n      - image: cimg/go\n    steps:\n      - checkout\n      - restore_cache:\n          key: go-mod-{{ checksum \"go.sum\" }}\n      - run:\n          name: Download Go modules\n          command: go mod download\n      - save_cache:\n          key: go-mod-{{ checksum \"go.sum\" }}\n          paths:\n            - /home/circleci/go/pkg/mod\n      - run:\n          name: Run go vet\n          command: go vet ./...\n      - run:\n          name: Run tests\n          command: gotestsum --junitfile junit.xml\n      - store_test_results:\n          path: junit.xml\nworkflows:\n  ci:\n    jobs:\n      - test-go\n"
 
 	c := codebase.LocalCodebase{BasePath: ".."}
-	matches := labeling.ApplyAllRules(c)
-	gotConfig := GenerateConfig(matches)
+	ls := labeling.ApplyAllRules(c)
+	gotConfig := GenerateConfig(ls)
 	testEncode(t, gotConfig, expectedConfig)
 }

--- a/generation/internal/common.go
+++ b/generation/internal/common.go
@@ -10,10 +10,10 @@ import (
 var checkoutStep = config.Step{Type: config.Checkout}
 
 // initialSteps returns a checkout step and, if necessary cd step
-func initialSteps(depsMatch labels.Match) []config.Step {
+func initialSteps(depsLabel labels.Label) []config.Step {
 	steps := []config.Step{checkoutStep}
 
-	basePath := depsMatch.BasePath
+	basePath := depsLabel.BasePath
 	if basePath != "." {
 		steps = append(steps, config.Step{
 			Type:    config.Run,

--- a/generation/internal/go.go
+++ b/generation/internal/go.go
@@ -7,8 +7,8 @@ import (
 
 const goCacheKey = `go-mod-{{ checksum "go.sum" }}`
 
-func goTestJob(matches labels.MatchSet) *Job {
-	steps := initialSteps(matches[labels.DepsGo])
+func goTestJob(ls labels.LabelSet) *Job {
+	steps := initialSteps(ls[labels.DepsGo])
 
 	steps = append(steps, []config.Step{
 		{
@@ -46,9 +46,9 @@ func goTestJob(matches labels.MatchSet) *Job {
 	}
 }
 
-func GenerateGoJobs(matches labels.MatchSet) []*Job {
-	if !matches[labels.DepsGo].Valid {
+func GenerateGoJobs(ls labels.LabelSet) []*Job {
+	if !ls[labels.DepsGo].Valid {
 		return nil
 	}
-	return []*Job{goTestJob(matches)}
+	return []*Job{goTestJob(ls)}
 }

--- a/generation/internal/jobs.go
+++ b/generation/internal/jobs.go
@@ -22,7 +22,7 @@ type Job struct {
 	Orbs map[string]string
 }
 
-func BuildConfig(matches labels.MatchSet, jobs []*Job) config.Config {
+func BuildConfig(ls labels.LabelSet, jobs []*Job) config.Config {
 	if len(jobs) == 0 {
 		return fallbackConfig
 	}
@@ -37,7 +37,7 @@ func BuildConfig(matches labels.MatchSet, jobs []*Job) config.Config {
 
 	return config.Config{
 		Comment: fmt.Sprintf("This config was automatically generated from your source code\n"+
-			"Stacks detected: %s", matches.String()),
+			"Stacks detected: %s", ls.String()),
 		Workflows: workflows,
 		Jobs:      configJobs,
 		Orbs:      buildOrbs(jobs),

--- a/generation/internal/node.go
+++ b/generation/internal/node.go
@@ -7,18 +7,18 @@ import (
 
 const nodeOrb = "circleci/node@5"
 
-func npmTaskDefined(matches labels.MatchSet, task string) bool {
-	return matches[labels.DepsNode].Tasks[task] != ""
+func npmTaskDefined(ls labels.LabelSet, task string) bool {
+	return ls[labels.DepsNode].Tasks[task] != ""
 }
 
-func nodeTestSteps(matches labels.MatchSet) []config.Step {
-	if matches[labels.TestJest].Valid {
+func nodeTestSteps(ls labels.LabelSet) []config.Step {
+	if ls[labels.TestJest].Valid {
 		return []config.Step{{
 			Type:    config.Run,
 			Command: "jest",
 		}}
 	}
-	if npmTaskDefined(matches, "test:ci") {
+	if npmTaskDefined(ls, "test:ci") {
 		return []config.Step{{
 			Type:    config.Run,
 			Command: "npm run test:ci",
@@ -31,14 +31,14 @@ func nodeTestSteps(matches labels.MatchSet) []config.Step {
 	}}
 }
 
-func nodeTestJob(matches labels.MatchSet) *Job {
-	steps := initialSteps(matches[labels.DepsNode])
+func nodeTestJob(ls labels.LabelSet) *Job {
+	steps := initialSteps(ls[labels.DepsNode])
 
 	steps = append(steps, config.Step{
 		Type:    config.OrbCommand,
 		Command: "node/install-packages",
 	})
-	steps = append(steps, nodeTestSteps(matches)...)
+	steps = append(steps, nodeTestSteps(ls)...)
 
 	return &Job{
 		Job: config.Job{Name: "test-node",
@@ -50,9 +50,9 @@ func nodeTestJob(matches labels.MatchSet) *Job {
 	}
 }
 
-func GenerateNodeJobs(matches labels.MatchSet) []*Job {
-	if !matches[labels.DepsNode].Valid {
+func GenerateNodeJobs(ls labels.LabelSet) []*Job {
+	if !ls[labels.DepsNode].Valid {
 		return nil
 	}
-	return []*Job{nodeTestJob(matches)}
+	return []*Job{nodeTestJob(ls)}
 }

--- a/labeling/internal/go.go
+++ b/labeling/internal/go.go
@@ -7,11 +7,11 @@ import (
 )
 
 var GoRules = []labels.Rule{
-	func(c codebase.Codebase, ms *labels.MatchSet) (m labels.Match, err error) {
-		m.Label = labels.DepsGo
+	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {
+		label.Key = labels.DepsGo
 		goModPath, err := c.FindFile("go.mod")
-		m.Valid = goModPath != ""
-		m.BasePath = path.Dir(goModPath)
-		return m, err
+		label.Valid = goModPath != ""
+		label.BasePath = path.Dir(goModPath)
+		return label, err
 	},
 }

--- a/labeling/internal/node.go
+++ b/labeling/internal/node.go
@@ -8,20 +8,20 @@ import (
 )
 
 var NodeRules = []labels.Rule{
-	func(c codebase.Codebase, ms *labels.MatchSet) (m labels.Match, err error) {
-		m.Label = labels.DepsNode
+	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {
+		label.Key = labels.DepsNode
 		packagePath := findPackageJSON(c)
-		m.Valid = packagePath != ""
-		if !m.Valid {
-			return m, err
+		label.Valid = packagePath != ""
+		if !label.Valid {
+			return label, err
 		}
-		err = readPackageJSON(c, packagePath, &m)
-		return m, err
+		err = readPackageJSON(c, packagePath, &label)
+		return label, err
 	},
-	func(c codebase.Codebase, ms *labels.MatchSet) (m labels.Match, err error) {
-		m.Label = labels.TestJest
-		m.Valid = hasDependency(ms, "jest")
-		return m, err
+	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {
+		label.Key = labels.TestJest
+		label.Valid = hasDependency(ls, "jest")
+		return label, err
 	},
 }
 
@@ -42,7 +42,7 @@ func findPackageJSON(c codebase.Codebase) string {
 	return file
 }
 
-func readPackageJSON(c codebase.Codebase, filePath string, match *labels.Match) error {
+func readPackageJSON(c codebase.Codebase, filePath string, label *labels.Label) error {
 	var packageJSON npmPackageJSON
 
 	fileContents, err := c.ReadFile(filePath)
@@ -55,20 +55,20 @@ func readPackageJSON(c codebase.Codebase, filePath string, match *labels.Match) 
 		return err
 	}
 
-	match.MatchData.BasePath = path.Dir(filePath)
-	match.Tasks = packageJSON.Scripts
-	match.Dependencies = make(map[string]string)
+	label.LabelData.BasePath = path.Dir(filePath)
+	label.Tasks = packageJSON.Scripts
+	label.Dependencies = make(map[string]string)
 
 	for k, v := range packageJSON.Dependencies {
-		match.Dependencies[k] = v
+		label.Dependencies[k] = v
 	}
 	for k, v := range packageJSON.DevDependencies {
-		match.Dependencies[k] = v
+		label.Dependencies[k] = v
 	}
 
 	return err
 }
 
-func hasDependency(ms *labels.MatchSet, dep string) bool {
-	return (*ms)[labels.DepsNode].Dependencies[dep] != ""
+func hasDependency(ls *labels.LabelSet, dep string) bool {
+	return (*ls)[labels.DepsNode].Dependencies[dep] != ""
 }

--- a/labeling/labeling.go
+++ b/labeling/labeling.go
@@ -6,27 +6,27 @@ import (
 	"github.com/CircleCI-Public/circleci-config/labeling/labels"
 )
 
-// ApplyRules applies the rules to a codebase.Codebase and returns a map of rule label to
-// valid codebase.Match
+// ApplyRules applies the rules to a codebase.Codebase and returns a map of label key to
+// valid codebase.Label
 // Order of rules is relevant, higher "salience" rules should come first, i.e. later rules can
-// depend on the MatchData of previous rules.
-func ApplyRules(c codebase.Codebase, rules []labels.Rule) labels.MatchSet {
-	matches := make(labels.MatchSet)
+// depend on the LabelData of previous rules.
+func ApplyRules(c codebase.Codebase, rules []labels.Rule) labels.LabelSet {
+	ls := make(labels.LabelSet)
 	for _, r := range rules {
-		match, err := r(c, &matches)
+		label, err := r(c, &ls)
 		if err != nil {
 			continue
 		}
 
-		if match.Valid {
-			matches[match.Label] = match
+		if label.Valid {
+			ls[label.Key] = label
 		}
 	}
 
-	return matches
+	return ls
 }
 
-func ApplyAllRules(c codebase.Codebase) labels.MatchSet {
+func ApplyAllRules(c codebase.Codebase) labels.LabelSet {
 	allStacks := [][]labels.Rule{
 		internal.NodeRules,
 		internal.GoRules,

--- a/labeling/labeling_test.go
+++ b/labeling/labeling_test.go
@@ -35,26 +35,26 @@ func (r fakeCodebase) ReadFile(path string) (contents []byte, err error) {
 
 func TestCodebase_ApplyAllRules(t *testing.T) {
 	tests := []struct {
-		name            string
-		files           map[string]string
-		expectedMatches []labels.Match
+		name           string
+		files          map[string]string
+		expectedLabels []labels.Label
 	}{
 		{
-			name: "go & node rules match",
+			name: "go & node rules apply",
 			files: map[string]string{
 				"go.mod":       "",
 				"package.json": "{}",
 			},
-			expectedMatches: []labels.Match{
+			expectedLabels: []labels.Label{
 				{
-					Label: labels.DepsNode,
-					MatchData: labels.MatchData{
+					Key: labels.DepsNode,
+					LabelData: labels.LabelData{
 						BasePath:     ".",
 						Dependencies: map[string]string{},
 					},
 				}, {
-					Label: labels.DepsGo,
-					MatchData: labels.MatchData{
+					Key: labels.DepsGo,
+					LabelData: labels.LabelData{
 						BasePath: ".",
 					},
 				},
@@ -64,11 +64,11 @@ func TestCodebase_ApplyAllRules(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := fakeCodebase{tt.files}
-			expected := make(labels.MatchSet)
-			for _, m := range tt.expectedMatches {
+			expected := make(labels.LabelSet)
+			for _, label := range tt.expectedLabels {
 				// all should be Valid
-				m.Valid = true
-				expected[m.Label] = m
+				label.Valid = true
+				expected[label.Key] = label
 			}
 			got := ApplyAllRules(c)
 
@@ -86,20 +86,20 @@ func TestCodebase_ApplyAllRules(t *testing.T) {
 func TestCodebase_ApplyRules_Node(t *testing.T) {
 	rules := internal.NodeRules
 	tests := []struct {
-		name            string
-		files           map[string]string
-		rules           []labels.Rule
-		expectedMatches []labels.Match
+		name           string
+		files          map[string]string
+		rules          []labels.Rule
+		expectedLabels []labels.Label
 	}{
 		{
 			name: "deps:node with package.json in subdir",
 			files: map[string]string{
 				"project/package.json": `{}`,
 			},
-			expectedMatches: []labels.Match{
+			expectedLabels: []labels.Label{
 				{
-					Label: labels.DepsNode,
-					MatchData: labels.MatchData{
+					Key: labels.DepsNode,
+					LabelData: labels.LabelData{
 						BasePath:     "project",
 						Dependencies: map[string]string{},
 					},
@@ -110,10 +110,10 @@ func TestCodebase_ApplyRules_Node(t *testing.T) {
 			files: map[string]string{
 				"package.json": `{"dependencies": {"mylib": ">3.0"}}`,
 			},
-			expectedMatches: []labels.Match{
+			expectedLabels: []labels.Label{
 				{
-					Label: labels.DepsNode,
-					MatchData: labels.MatchData{
+					Key: labels.DepsNode,
+					LabelData: labels.LabelData{
 						BasePath:     ".",
 						Dependencies: map[string]string{"mylib": ">3.0"},
 					},
@@ -124,10 +124,10 @@ func TestCodebase_ApplyRules_Node(t *testing.T) {
 			files: map[string]string{
 				"package.json": `{"dependencies": {"mylib": ">3.0"}, "scripts": {"test": "echo ok"}}`,
 			},
-			expectedMatches: []labels.Match{
+			expectedLabels: []labels.Label{
 				{
-					Label: labels.DepsNode,
-					MatchData: labels.MatchData{
+					Key: labels.DepsNode,
+					LabelData: labels.LabelData{
 						BasePath:     ".",
 						Dependencies: map[string]string{"mylib": ">3.0"},
 						Tasks:        map[string]string{"test": "echo ok"},
@@ -139,10 +139,10 @@ func TestCodebase_ApplyRules_Node(t *testing.T) {
 			files: map[string]string{
 				"package.json": `{"dependencies": {"mylib": ">3.0"}, "devDependencies": {"jest": "1.0"}}`,
 			},
-			expectedMatches: []labels.Match{
+			expectedLabels: []labels.Label{
 				{
-					Label: labels.DepsNode,
-					MatchData: labels.MatchData{
+					Key: labels.DepsNode,
+					LabelData: labels.LabelData{
 						BasePath: ".",
 						Dependencies: map[string]string{
 							"mylib": ">3.0",
@@ -150,7 +150,7 @@ func TestCodebase_ApplyRules_Node(t *testing.T) {
 						},
 					},
 				}, {
-					Label: labels.TestJest,
+					Key: labels.TestJest,
 				},
 			},
 		},
@@ -158,11 +158,11 @@ func TestCodebase_ApplyRules_Node(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := fakeCodebase{tt.files}
-			expected := make(labels.MatchSet)
-			for _, m := range tt.expectedMatches {
+			expected := make(labels.LabelSet)
+			for _, label := range tt.expectedLabels {
 				// all should be Valid
-				m.Valid = true
-				expected[m.Label] = m
+				label.Valid = true
+				expected[label.Key] = label
 			}
 			got := ApplyRules(c, rules)
 
@@ -180,20 +180,20 @@ func TestCodebase_ApplyRules_Node(t *testing.T) {
 func TestCodebase_ApplyRules_Go(t *testing.T) {
 	rules := internal.GoRules
 	tests := []struct {
-		name            string
-		files           map[string]string
-		rules           []labels.Rule
-		expectedMatches []labels.Match
+		name           string
+		files          map[string]string
+		rules          []labels.Rule
+		expectedLabels []labels.Label
 	}{
 		{
 			name: "deps:go",
 			files: map[string]string{
 				"go.mod": "module mymod\n\ngo 1.18\n",
 			},
-			expectedMatches: []labels.Match{
+			expectedLabels: []labels.Label{
 				{
-					Label: labels.DepsGo,
-					MatchData: labels.MatchData{
+					Key: labels.DepsGo,
+					LabelData: labels.LabelData{
 						BasePath: ".",
 					},
 				},
@@ -203,11 +203,11 @@ func TestCodebase_ApplyRules_Go(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := fakeCodebase{tt.files}
-			expected := make(labels.MatchSet)
-			for _, m := range tt.expectedMatches {
+			expected := make(labels.LabelSet)
+			for _, label := range tt.expectedLabels {
 				// all should be Valid
-				m.Valid = true
-				expected[m.Label] = m
+				label.Valid = true
+				expected[label.Key] = label
 			}
 			got := ApplyRules(c, rules)
 

--- a/labeling/labels/labels.go
+++ b/labeling/labels/labels.go
@@ -13,38 +13,38 @@ const (
 	DepsGo   = "deps:go"
 )
 
-type MatchData struct {
+type LabelData struct {
 	BasePath     string
 	Dependencies map[string]string
 	Tasks        map[string]string
 }
 
-// Match is the result of applying a Rule
-type Match struct {
-	Label     string // Label of the matching rule
-	Valid     bool   // If the rule matched, Valid = true
-	MatchData        // MatchData rule-specific data for each match
+// Label is the result of applying a Rule
+type Label struct {
+	Key       string // string identifying the label, like "deps:go"
+	Valid     bool   // If the rule applies, Valid = true
+	LabelData        // LabelData rule-specific data for each label
 }
 
-func (m Match) String() string {
-	if m.Valid {
-		return fmt.Sprintf("%s:%s", m.Label, m.BasePath)
+func (label Label) String() string {
+	if label.Valid {
+		return fmt.Sprintf("%s:%s", label.Key, label.BasePath)
 	} else {
-		return fmt.Sprintf("!%s", m.Label)
+		return fmt.Sprintf("!%s", label.Key)
 	}
 }
 
-type MatchSet map[string]Match
+type LabelSet map[string]Label
 
-func (m MatchSet) String() string {
-	matchStrings := make([]string, len(m))
+func (ls LabelSet) String() string {
+	labelsAsStrings := make([]string, len(ls))
 	i := 0
-	for _, v := range m {
-		matchStrings[i] = v.String()
+	for _, v := range ls {
+		labelsAsStrings[i] = v.String()
 		i++
 	}
-	sort.Strings(matchStrings)
-	return strings.Join(matchStrings, ",")
+	sort.Strings(labelsAsStrings)
+	return strings.Join(labelsAsStrings, ",")
 }
 
-type Rule func(codebase.Codebase, *MatchSet) (Match, error)
+type Rule func(codebase.Codebase, *LabelSet) (Label, error)

--- a/labeling/labels/labels_test.go
+++ b/labeling/labels/labels_test.go
@@ -2,25 +2,25 @@ package labels
 
 import "testing"
 
-func TestMatch_String(t *testing.T) {
+func TestLabel_String(t *testing.T) {
 	tests := []struct {
 		name      string
 		Label     string
-		Valid     bool
-		MatchData MatchData
+		valid     bool
+		labelData LabelData
 		expected  string
 	}{
 		{
 			name:      "invalid",
 			Label:     "label",
-			Valid:     false,
-			MatchData: MatchData{},
+			valid:     false,
+			labelData: LabelData{},
 			expected:  "!label",
 		}, {
 			name:  "valid",
 			Label: "label",
-			Valid: true,
-			MatchData: MatchData{
+			valid: true,
+			labelData: LabelData{
 				BasePath: ".",
 			},
 			expected: "label:.",
@@ -28,12 +28,12 @@ func TestMatch_String(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := Match{
-				Label:     tt.Label,
-				Valid:     tt.Valid,
-				MatchData: tt.MatchData,
+			label := Label{
+				Key:       tt.Label,
+				Valid:     tt.valid,
+				LabelData: tt.labelData,
 			}
-			got := m.String()
+			got := label.String()
 			if got != tt.expected {
 				t.Errorf("String() = %v, expected %v", got, tt.expected)
 			}
@@ -41,28 +41,28 @@ func TestMatch_String(t *testing.T) {
 	}
 }
 
-func TestMatchSet_String(t *testing.T) {
+func TestLabelSet_String(t *testing.T) {
 	tests := []struct {
 		name     string
-		matchSet MatchSet
+		labels   LabelSet
 		expected string
 	}{
 		{
 			name:     "empty",
-			matchSet: MatchSet{},
+			labels:   LabelSet{},
 			expected: "",
 		}, {
-			name: "3 matches, sorted",
-			matchSet: MatchSet{
-				DepsGo:   {Label: DepsGo, Valid: true},
-				TestJest: {Label: TestJest, Valid: true},
-				DepsNode: {Label: DepsNode, Valid: true}},
+			name: "3 labels, sorted",
+			labels: LabelSet{
+				DepsGo:   {Key: DepsGo, Valid: true},
+				TestJest: {Key: TestJest, Valid: true},
+				DepsNode: {Key: DepsNode, Valid: true}},
 			expected: "deps:go:,deps:node:,test:jest:",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.matchSet.String()
+			got := tt.labels.String()
 			if got != tt.expected {
 				t.Errorf("String() = %v, expected %v", got, tt.expected)
 			}


### PR DESCRIPTION
After a conversation with @okmoses decided to rename the concepts of labeling:

- Rules apply to codebases and return a Label with Valid = true, if the label applies to that codebase
- Labels have a Key (an immutable string) and LabelData for extra information
- Applying multiple rules to a codebase returns a LabelSet, which is a map of tags to Labels