### PR TITLE
Add support for yarn package manager

### DIFF
--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -3,12 +3,13 @@ package generation
 import (
 	"bytes"
 	"fmt"
+	"testing"
+
 	"github.com/CircleCI-Public/circleci-config/config"
 	"github.com/CircleCI-Public/circleci-config/labeling"
 	"github.com/CircleCI-Public/circleci-config/labeling/codebase"
 	"github.com/CircleCI-Public/circleci-config/labeling/labels"
 	"gopkg.in/yaml.v3"
-	"testing"
 )
 
 func mustEncode(node *yaml.Node) string {
@@ -64,7 +65,8 @@ jobs:
       - run:
           name: Change into 'node-dir' directory
           command: cd 'node-dir'
-      - node/install-packages
+      - node/install-packages:
+          pkg-manager: npm
       - run:
           command: npm test
   test-go:
@@ -98,6 +100,41 @@ workflows:
     jobs:
       - test-node
       - test-go
+`,
+		},
+		{
+			testName: "node codebase with yarn.lock",
+			labels: labels.LabelSet{
+				labels.DepsNode: labels.Label{
+					Key:       labels.DepsNode,
+					Valid:     true,
+					LabelData: labels.LabelData{BasePath: "."},
+				},
+				labels.PackageManagerYarn: labels.Label{
+					Key:       labels.PackageManagerYarn,
+					Valid:     true,
+					LabelData: labels.LabelData{BasePath: "."},
+				},
+			},
+			expected: `# This config was automatically generated from your source code
+# Stacks detected: deps:node:.,package_manager:yarn:.
+version: 2.1
+orbs:
+  node: circleci/node@5
+jobs:
+  test-node:
+    # Install node dependencies and run tests
+    executor: node/default
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: yarn
+      - run:
+          command: yarn test
+workflows:
+  ci:
+    jobs:
+      - test-node
 `,
 		},
 	}

--- a/labeling/internal/node.go
+++ b/labeling/internal/node.go
@@ -2,9 +2,10 @@ package internal
 
 import (
 	"encoding/json"
+	"path"
+
 	"github.com/CircleCI-Public/circleci-config/labeling/codebase"
 	"github.com/CircleCI-Public/circleci-config/labeling/labels"
-	"path"
 )
 
 var NodeRules = []labels.Rule{
@@ -16,6 +17,12 @@ var NodeRules = []labels.Rule{
 			return label, err
 		}
 		err = readPackageJSON(c, packagePath, &label)
+		return label, err
+	},
+	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {
+		label.Key = labels.PackageManagerYarn
+		yarnLock, _ := c.FindFile("yarn.lock")
+		label.Valid = yarnLock != ""
 		return label, err
 	},
 	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {

--- a/labeling/labeling_test.go
+++ b/labeling/labeling_test.go
@@ -2,11 +2,12 @@ package labeling
 
 import (
 	"fmt"
-	"github.com/CircleCI-Public/circleci-config/labeling/internal"
-	"github.com/CircleCI-Public/circleci-config/labeling/labels"
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/CircleCI-Public/circleci-config/labeling/internal"
+	"github.com/CircleCI-Public/circleci-config/labeling/labels"
 )
 
 // a codebase.Codebase for testing that just reads filenames and contents from a map
@@ -163,6 +164,30 @@ func TestCodebase_ApplyRules_Node(t *testing.T) {
 						},
 					},
 				}, {
+					Key: labels.TestJest,
+				},
+			},
+		},
+		{
+			name: "deps:node, scripts and package_manager:yarn",
+			files: map[string]string{
+				"package.json": `{"dependencies": {"mylib": ">3.0"}, "devDependencies": {"jest": "1.0"}}`,
+				"yarn.lock":    "yarn.lock file",
+			},
+			expectedLabels: []labels.Label{
+				{
+					Key: labels.DepsNode,
+					LabelData: labels.LabelData{
+						BasePath: ".",
+						Dependencies: map[string]string{
+							"mylib": ">3.0",
+							"jest":  "1.0",
+						},
+					},
+				}, {
+					Key: labels.PackageManagerYarn,
+				},
+				{
 					Key: labels.TestJest,
 				},
 			},

--- a/labeling/labels/labels.go
+++ b/labeling/labels/labels.go
@@ -2,12 +2,14 @@ package labels
 
 import (
 	"fmt"
-	"github.com/CircleCI-Public/circleci-config/labeling/codebase"
 	"sort"
 	"strings"
+
+	"github.com/CircleCI-Public/circleci-config/labeling/codebase"
 )
 
 const (
+	PackageManagerYarn   = "package_manager:yarn"
 	DepsNode             = "deps:node"
 	TestJest             = "test:jest"
 	DepsGo               = "deps:go"


### PR DESCRIPTION
Add support for the yarn packager manager for node projects so that install deps and tests can be run with yarn instead of npm when the project is using yarn.
