### PR TITLE
Store test results when using Jest

### DIFF
--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -68,6 +68,7 @@ jobs:
       - node/install-packages:
           pkg-manager: npm
       - run:
+          name: Run tests
           command: npm test
   test-go:
     # Install go modules, run go vet and tests
@@ -130,6 +131,7 @@ jobs:
       - node/install-packages:
           pkg-manager: yarn
       - run:
+          name: Run tests
           command: yarn test
 workflows:
   ci:
@@ -169,6 +171,7 @@ jobs:
       - run:
           command: npm install jest-junit
       - run:
+          name: Run tests with Jest
           command: jest --ci --runInBand --reporters=default --reporters=jest-junit
       - store_test_results:
           path: ./test-results/

--- a/generation/internal/node.go
+++ b/generation/internal/node.go
@@ -18,6 +18,7 @@ func nodeTestSteps(ls labels.LabelSet, packageManager string) []config.Step {
 
 	if npmTaskDefined(ls, "test:ci") {
 		return []config.Step{{
+			Name:    "Run tests",
 			Type:    config.Run,
 			Command: fmt.Sprintf("%s run test:ci", packageManager),
 		}}
@@ -26,12 +27,14 @@ func nodeTestSteps(ls labels.LabelSet, packageManager string) []config.Step {
 	if npmTaskDefined(ls, "test") {
 		if hasJestLabel {
 			return []config.Step{{
+				Name:    "Run tests",
 				Type:    config.Run,
 				Command: fmt.Sprintf("%s run test --ci --runInBand --reporters=default --reporters=jest-junit", packageManager),
 			}}
 		}
 
 		return []config.Step{{
+			Name:    "Run tests",
 			Type:    config.Run,
 			Command: fmt.Sprintf("%s run test", packageManager),
 		}}
@@ -40,11 +43,13 @@ func nodeTestSteps(ls labels.LabelSet, packageManager string) []config.Step {
 	if hasJestLabel {
 		return []config.Step{{
 			Type:    config.Run,
+			Name:    "Run tests with Jest",
 			Command: "jest --ci --runInBand --reporters=default --reporters=jest-junit",
 		}}
 	}
 
 	return []config.Step{{
+		Name:    "Run tests",
 		Type:    config.Run,
 		Command: fmt.Sprintf("%s test", packageManager),
 	}}
@@ -84,7 +89,8 @@ func nodeTestJob(ls labels.LabelSet) *Job {
 		})
 	}
 
-	job := config.Job{Name: "test-node",
+	job := config.Job{
+		Name:     "test-node",
 		Comment:  "Install node dependencies and run tests",
 		Executor: "node/default",
 		Steps:    steps}


### PR DESCRIPTION
When the project has `Jest` tests:

- Install JUnit coverage reporter
- Run tests with JUnit as reporter
- Store the test results

Example generated config:
```yaml
# This config was automatically generated from your source code
# Stacks detected: deps:node:.,package_manager:yarn:,test:jest:
version: 2.1
orbs:
  node: circleci/node@5
jobs:
  test-node:
    # Install node dependencies and run tests
    executor: node/default
    environment:
      JEST_JUNIT_OUTPUT_DIR: ./test-results/
    steps:
      - checkout
      - node/install-packages:
          pkg-manager: yarn
      - run:
          command: npm install jest-junit
      - run:
          command: yarn run test --ci --runInBand --reporters=default --reporters=jest-junit
      - store_test_results:
          path: ./test-results/
workflows:
  ci:
    jobs:
      - test-node
```