### PR TITLE
Install jest-junit with yarn

### DIFF
--- a/cmd/inferconfig/testdata/expected/circleci-demo-react-native.yml
+++ b/cmd/inferconfig/testdata/expected/circleci-demo-react-native.yml
@@ -14,7 +14,7 @@ jobs:
       - node/install-packages:
           pkg-manager: yarn
       - run:
-          command: npm install jest-junit
+          command: yarn add jest-junit
       - run:
           name: Run tests
           command: yarn run test --ci --runInBand --reporters=default --reporters=jest-junit

--- a/generation/internal/node.go
+++ b/generation/internal/node.go
@@ -72,10 +72,17 @@ func nodeTestJob(ls labels.LabelSet) *Job {
 		},
 	})
 	if hasJestLabel {
-		steps = append(steps, config.Step{
-			Type:    config.Run,
-			Command: "npm install jest-junit",
-		})
+		if packageManager == "yarn" {
+			steps = append(steps, config.Step{
+				Type:    config.Run,
+				Command: "yarn add jest-junit",
+			})
+		} else {
+			steps = append(steps, config.Step{
+				Type:    config.Run,
+				Command: "npm install jest-junit",
+			})
+		}
 	}
 	steps = append(steps, nodeTestSteps(ls, packageManager)...)
 


### PR DESCRIPTION
When the node project is using yarn, install jest-junit with yarn in the test job.
