### PR TITLE
Add job to validate inferred configs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,21 @@ jobs:
           command: diff ./config.yml cmd/inferconfig/testdata/expected/dogfood.yml
       - continuation/continue:
           configuration_path: ./config.yml
+  validate-inferred-configs:
+    docker:
+        - image: circleci/circleci-cli
+    steps:
+      - checkout
+      - run:
+          name: Validate inferred configs
+          command: |
+            set -e
+            for file in ./cmd/inferconfig/testdata/expected/*; do
+                circleci config validate "$file"
+            done
 
 workflows:
   inference:
     jobs:
       - infer-own-config
+      - validate-inferred-configs


### PR DESCRIPTION
To make sure the inferred configs are valid, we would like to add a CI job to validate the configs.
