### PR TITLE
Add workflow jobs dependencies for ruby tests

### DIFF
--- a/cmd/inferconfig/testdata/expected/circleci-demo-ruby-rails.yml
+++ b/cmd/inferconfig/testdata/expected/circleci-demo-ruby-rails.yml
@@ -46,4 +46,7 @@ workflows:
     jobs:
       - test-node
       - test-ruby
-    # - deploy
+    # - deploy:
+    #     requires:
+    #       - test-node
+    #       - test-ruby


### PR DESCRIPTION
Didn't rebase main before merging my [PR](https://github.com/CircleCI-Public/circleci-config/pull/14) which failed the build on main
