### PR TITLE
Fallback to current ruby version when not found in gemfile

### DIFF
--- a/generation/internal/ruby.go
+++ b/generation/internal/ruby.go
@@ -62,9 +62,18 @@ func rspecJob(ls labels.LabelSet) *Job {
 	}
 }
 
+const rubyFallbackVersion = "3.2"
+
 // Construct the ruby image tag based on the ruby version
 func rubyImageVersion(ls labels.LabelSet) string {
 	prefix := "cimg/ruby:"
 	suffix := "-node"
-	return prefix + ls[labels.PackageManagerBundler].Dependencies["ruby"] + suffix
+	version := rubyFallbackVersion
+
+	gemfileVersion := ls[labels.PackageManagerBundler].Dependencies["ruby"]
+	if gemfileVersion != "" {
+		version = gemfileVersion
+	}
+
+	return prefix + version + suffix
 }

--- a/generation/internal/ruby_test.go
+++ b/generation/internal/ruby_test.go
@@ -1,0 +1,52 @@
+package internal
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/CircleCI-Public/circleci-config/labeling/labels"
+)
+
+func Test_rubyImageVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		labels          labels.LabelSet
+		expectedVersion string
+	}{
+		{
+			name: "version in gemfile",
+			labels: labels.LabelSet{
+				labels.PackageManagerBundler: labels.Label{
+					Key: labels.PackageManagerBundler,
+					LabelData: labels.LabelData{
+						Dependencies: map[string]string{
+							"ruby": "2.9.2",
+						},
+					},
+				},
+			},
+			expectedVersion: "cimg/ruby:2.9.2-node",
+		},
+		{
+			name: "no version in gemfile - use fallback",
+			labels: labels.LabelSet{
+				labels.PackageManagerBundler: labels.Label{
+					Key: labels.PackageManagerBundler,
+				},
+			},
+			expectedVersion: "cimg/ruby:3.2-node",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rubyImageVersion(tt.labels)
+			if !reflect.DeepEqual(got, tt.expectedVersion) {
+				t.Errorf("\n"+
+					"got      %v\n"+
+					"expected %v",
+					got,
+					tt.expectedVersion)
+			}
+		})
+	}
+}


### PR DESCRIPTION
If we can't pull the ruby version from the Gemfile, use the current latest version for running rspec tests.