### PR TITLE
Walk the full codebase when looking for files.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/CircleCI-Public/circleci-config
 
-go 1.18
+go 1.20
 
 require gopkg.in/yaml.v3 v3.0.1
 

--- a/labeling/codebase/localcodebase_test.go
+++ b/labeling/codebase/localcodebase_test.go
@@ -52,50 +52,55 @@ func TestLocalCodebase_FindFile(t *testing.T) {
 	tests := []struct {
 		name         string
 		BasePath     string
-		glob         string
+		globs        []string
 		expectedPath string
 		expectErr    bool
 	}{
 		{
 			name:         "find.me found in testdata dir",
 			BasePath:     "./testdata",
-			glob:         "find.me",
+			globs:        []string{"find.me"},
 			expectedPath: "find.me",
-			expectErr:    false,
 		}, {
 			name:         "find.me found in current dir by glob",
 			BasePath:     ".",
-			glob:         "*/find.me",
+			globs:        []string{"find.me"},
 			expectedPath: "testdata/find.me",
-			expectErr:    false,
+		}, {
+			name:         "find.me found in current dir by extension",
+			BasePath:     ".",
+			globs:        []string{"*.me"},
+			expectedPath: "testdata/find.me",
 		}, {
 			name:         "find.me found in current dir by exact path",
 			BasePath:     ".",
-			glob:         "testdata/find.me",
+			globs:        []string{"testdata/find.me"},
 			expectedPath: "testdata/find.me",
-			expectErr:    false,
+		}, {
+			name:         "find.me found in current dir, multiple globs, first matches",
+			BasePath:     ".",
+			globs:        []string{"find.me", "dontfind.me"},
+			expectedPath: "testdata/find.me",
+		}, {
+			name:         "find.me found in current dir, multiple globs, last matches",
+			BasePath:     ".",
+			globs:        []string{"dontfind.me", "find.me"},
+			expectedPath: "testdata/find.me",
 		}, {
 			name:         "localcodebase_test.go found in current dir",
 			BasePath:     ".",
-			glob:         "localcodebase_test.go",
+			globs:        []string{"localcodebase_test.go"},
 			expectedPath: "localcodebase_test.go",
-			expectErr:    false,
 		}, {
 			name:         "localcodebase_test.go found in current dir without BasePath",
-			glob:         "localcodebase_test.go",
+			globs:        []string{"localcodebase_test.go"},
 			expectedPath: "localcodebase_test.go",
-			expectErr:    false,
-		}, {
-			name:      "find.me not found in current dir",
-			BasePath:  ".",
-			glob:      "find.me",
-			expectErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := LocalCodebase{BasePath: tt.BasePath}
-			gotPath, err := c.FindFile(tt.glob)
+			gotPath, err := c.FindFile(tt.globs...)
 			if (err != nil) != tt.expectErr {
 				t.Errorf("FindFile() error %v, expectErr %v", err, tt.expectErr)
 				return

--- a/labeling/internal/go.go
+++ b/labeling/internal/go.go
@@ -11,7 +11,7 @@ import (
 var GoRules = []labels.Rule{
 	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {
 		label.Key = labels.DepsGo
-		goModPath, err := c.FindFile("go.mod", "*/go.mod")
+		goModPath, err := c.FindFile("go.mod")
 		label.Valid = goModPath != ""
 		label.BasePath = path.Dir(goModPath)
 		return label, err
@@ -33,8 +33,6 @@ func containsMainGoFiles(c codebase.Codebase) bool {
 			return isMainPackageGoFile(c, path)
 		},
 		"*.go",
-		"*/*.go",
-		"cmd/*/*.go",
 	)
 	return err == nil
 }

--- a/labeling/internal/node.go
+++ b/labeling/internal/node.go
@@ -40,7 +40,7 @@ type npmPackageJSON struct {
 }
 
 func findPackageJSON(c codebase.Codebase) string {
-	file, _ := c.FindFile("package.json", "*/package.json")
+	file, _ := c.FindFile("package.json")
 	return file
 }
 

--- a/labeling/internal/python.go
+++ b/labeling/internal/python.go
@@ -9,14 +9,11 @@ import (
 
 var pipenvFiles = []string{
 	"Pipfile",
-	"*/Pipfile",
 	"Pipfile.lock",
-	"*/Pipfile.lock",
 }
 
 var poetryFiles = []string{
 	"pyproject.toml",
-	"*/pyproject.toml",
 	"poetry.lock",
 }
 
@@ -25,7 +22,6 @@ var possiblePythonFiles = append(
 	append(
 		[]string{
 			"requirements.txt",
-			"*/requirements.txt",
 		},
 		pipenvFiles...,
 	),

--- a/labeling/internal/ruby.go
+++ b/labeling/internal/ruby.go
@@ -11,7 +11,7 @@ import (
 var RubyRules = []labels.Rule{
 	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {
 		label.Key = labels.DepsRuby
-		gemfilePath, err := c.FindFile("Gemfile", "*/Gemfile")
+		gemfilePath, err := c.FindFile("Gemfile")
 		label.Valid = gemfilePath != ""
 		label.BasePath = path.Dir(gemfilePath)
 		return readGemfile(c, label, gemfilePath)

--- a/labeling/labeling_test.go
+++ b/labeling/labeling_test.go
@@ -19,8 +19,9 @@ type fakeCodebase struct {
 func (c fakeCodebase) FindFileMatching(predicate func(string) bool, globs ...string) (string, error) {
 	for _, g := range globs {
 		for path := range c.contentsByPath {
-			matched, _ := filepath.Match(g, path)
-			if matched && predicate(path) {
+			matchesName, _ := filepath.Match(g, filepath.Base(path))
+			matchesPath, _ := filepath.Match(g, path)
+			if (matchesName || matchesPath) && predicate(path) {
 				return path, nil
 			}
 		}


### PR DESCRIPTION
Walk the full codebase when looking for files.

This, of course, changes the semantics of `FindFile` somewhat.
It's no longer possible to find 1 specific file by exact path (but then you could just try to read it)

go updated to have access to `filepath.SkipAll`

Also wondering if we should timeout or stop at a certain depth.