### PR TITLE
In LocalCodebase, only walk the file tree once

### DIFF
--- a/labeling/codebase/localcodebase.go
+++ b/labeling/codebase/localcodebase.go
@@ -7,20 +7,53 @@ import (
 	"path/filepath"
 )
 
+const maxFiles = 250000
+
 // LocalCodebase is a Codebase for files available on local disk
 type LocalCodebase struct {
 	BasePath string
+	fileSet  []string
 }
 
 func (c LocalCodebase) FindFileMatching(
 	predicate func(string) bool,
 	glob ...string,
-) (foundPath string, err error) {
+) (string, error) {
+	files, err := c.files()
+	if err != nil {
+		return "", err
+	}
+
+	for _, path := range files {
+		for _, g := range glob {
+			matchesName, _ := filepath.Match(g, filepath.Base(path))
+			matchesPath, _ := filepath.Match(g, path)
+			if !(matchesName || matchesPath) {
+				continue
+			}
+			if predicate(path) {
+				return path, err
+			}
+		}
+	}
+
+	return "", fmt.Errorf("not found")
+
+}
+
+func (c LocalCodebase) files() ([]string, error) {
+	if len(c.fileSet) > 0 {
+		return c.fileSet, nil
+	}
+
 	basePath := c.BasePath
 	if basePath == "" {
 		basePath = "."
 	}
-	err = filepath.WalkDir(
+
+	filesVisited := 0
+	var fileList []string
+	err := filepath.WalkDir(
 		basePath,
 		func(path string, d fs.DirEntry, fileError error) error {
 			if fileError != nil {
@@ -30,29 +63,17 @@ func (c LocalCodebase) FindFileMatching(
 			if innerErr != nil {
 				return innerErr
 			}
-			for _, g := range glob {
-				matchesName, _ := filepath.Match(g, d.Name())
-				matchesPath, _ := filepath.Match(g, relPath)
-				if !(matchesName || matchesPath) {
-					continue
-				}
-				if predicate(relPath) {
-					foundPath = relPath
-					return filepath.SkipAll
-				}
+			fileList = append(fileList, relPath)
+			filesVisited++
+			if filesVisited >= maxFiles {
+				return filepath.SkipAll
 			}
 			return nil
 		})
 
-	if err != nil {
-		return foundPath, err
-	}
+	c.fileSet = fileList
 
-	if foundPath == "" {
-		return foundPath, fmt.Errorf("not found")
-	}
-
-	return foundPath, nil
+	return c.fileSet, err
 }
 
 func (c LocalCodebase) FindFile(glob ...string) (path string, err error) {


### PR DESCRIPTION
In LocalCodebase, only walk the file tree once and store a list of known files.

Of course, that means we always have to walk the whole tree and can't exit early on a match. But that's going to be the case for almost all codebases, anyways (unless they match _all_ rules). The memory usage seems acceptable from tests (in the order of 10s of megs).

Also stop after 250k files.

There's probably room for further optimizing this, by e.g. calling filepath.Base on each file only once, or perhaps stopping at a certain dir depth, but this at least puts an upper bound on execution time.

If we again changed the interface of LocalCodebase to be stricter in what globs it accepts we could also store the files in a set, which would probably be much faster.