### PR TITLE
Skip check for unkeyed composite literals with go vet

### DIFF
--- a/cmd/inferconfig/testdata/expected/circleci-demo-go.yml
+++ b/cmd/inferconfig/testdata/expected/circleci-demo-go.yml
@@ -19,7 +19,7 @@ jobs:
             - /home/circleci/go/pkg/mod
       - run:
           name: Run go vet
-          command: go vet ./...
+          command: go vet -composites=false ./...
       - run:
           name: Run tests
           command: gotestsum --junitfile junit.xml

--- a/cmd/inferconfig/testdata/expected/dogfood.yml
+++ b/cmd/inferconfig/testdata/expected/dogfood.yml
@@ -19,7 +19,7 @@ jobs:
             - /home/circleci/go/pkg/mod
       - run:
           name: Run go vet
-          command: go vet ./...
+          command: go vet -composites=false ./...
       - run:
           name: Run tests
           command: gotestsum --junitfile junit.xml

--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -140,7 +140,7 @@ jobs:
             - /home/circleci/go/pkg/mod
       - run:
           name: Run go vet
-          command: go vet ./...
+          command: go vet -composites=false ./...
       - run:
           name: Run tests
           command: gotestsum --junitfile junit.xml

--- a/generation/internal/go.go
+++ b/generation/internal/go.go
@@ -34,7 +34,7 @@ func goTestJob(ls labels.LabelSet) *Job {
 		{
 			Type:    config.Run,
 			Name:    "Run go vet",
-			Command: "go vet ./...",
+			Command: "go vet -composites=false ./...",
 		}, {
 			Type:    config.Run,
 			Name:    "Run tests",


### PR DESCRIPTION
Too easy to get false positives.
See also https://pkg.go.dev/cmd/vet#pkg-overview