### PR TITLE
Fix app-dir for node and ruby orbs

### DIFF
--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -116,6 +116,7 @@ jobs:
           name: Change into 'node-dir' directory
           command: cd 'node-dir'
       - node/install-packages:
+          app-dir: node-dir
           pkg-manager: npm
       - run:
           name: Run tests

--- a/generation/internal/common.go
+++ b/generation/internal/common.go
@@ -25,6 +25,15 @@ func initialSteps(depsLabel labels.Label) []config.Step {
 	return steps
 }
 
+func withOrbAppDir(parameters config.OrbCommandParameters, depsLabel labels.Label) config.OrbCommandParameters {
+	basePath := depsLabel.BasePath
+	if basePath != "" && basePath != "." {
+		parameters["app-dir"] = basePath
+	}
+
+	return parameters
+}
+
 const artifactsPath = "~/artifacts"
 
 var createArtifactsDirStep = config.Step{

--- a/generation/internal/ruby.go
+++ b/generation/internal/ruby.go
@@ -18,11 +18,13 @@ func GenerateRubyJobs(ls labels.LabelSet) (jobs []*Job) {
 }
 
 func rubyInitialSteps(ls labels.LabelSet) []config.Step {
-	steps := initialSteps(ls[labels.DepsRuby])
+	depsLabel := ls[labels.DepsRuby]
+	steps := initialSteps(depsLabel)
 
 	steps = append(steps, config.Step{
-		Type:    config.OrbCommand,
-		Command: "ruby/install-deps",
+		Type:       config.OrbCommand,
+		Command:    "ruby/install-deps",
+		Parameters: withOrbAppDir(config.OrbCommandParameters{}, depsLabel),
 	})
 	return steps
 }
@@ -32,6 +34,9 @@ const postgresImage = "circleci/postgres:9.5-alpine"
 
 func rspecJob(ls labels.LabelSet) *Job {
 	steps := rubyInitialSteps(ls)
+
+	depsLabel := ls[labels.DepsRuby]
+
 	steps = append(steps,
 		config.Step{
 			Type:    config.Run,
@@ -42,10 +47,10 @@ func rspecJob(ls labels.LabelSet) *Job {
 			Name:    "Database setup",
 			Command: "bundle exec rake db:test:prepare"},
 		config.Step{
-
-			Type:    config.OrbCommand,
-			Name:    "rspec test",
-			Command: "ruby/rspec-test"})
+			Type:       config.OrbCommand,
+			Name:       "rspec test",
+			Command:    "ruby/rspec-test",
+			Parameters: withOrbAppDir(config.OrbCommandParameters{}, depsLabel)})
 
 	images := []string{rubyImageVersion(ls)}
 	if ls[labels.DepsRuby].Dependencies["pg"] == "true" {


### PR DESCRIPTION
CircleCI orbs expect app-dir to be set, it's not sufficient to cd into a dir in a previous step.

Pending: doing the same for python.