### PR TITLE
Fix working dir problems for jobs that have a basepath different than the root

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -135,10 +135,11 @@ type Job struct {
 	Name    string
 	Comment string
 	// The following two fields are mutually exclusive
-	DockerImages []string
-	Executor     string
-	Steps        []Step
-	Environment  map[string]string
+	DockerImages     []string
+	Executor         string
+	WorkingDirectory string
+	Steps            []Step
+	Environment      map[string]string
 }
 
 func (j Job) YamlNode() *yaml.Node {
@@ -157,6 +158,10 @@ func (j Job) YamlNode() *yaml.Node {
 			imageNodes = append(imageNodes, yMap(yScalar("image"), yScalar(img)))
 		}
 		contentNodes = append(contentNodes, yScalar("docker"), ySeq(imageNodes...))
+	}
+
+	if j.WorkingDirectory != "" && j.WorkingDirectory != "." {
+		contentNodes = append(contentNodes, yScalar("working_directory"), yScalar(j.WorkingDirectory))
 	}
 
 	if len(j.Environment) > 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -203,7 +203,12 @@ type Step struct {
 func (s Step) YamlNode() *yaml.Node {
 	switch s.Type {
 	case Checkout:
-		return yCommentedScalar(s.Comment, "checkout")
+		if s.Path == "" {
+			return yCommentedScalar(s.Comment, "checkout")
+		} else {
+			return yCommentedMap(s.Comment, yScalar("checkout"),
+				yMap(yScalar("path"), yScalar(s.Path)))
+		}
 
 	case Run:
 		var kvs []*yaml.Node

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -428,6 +428,15 @@ steps:
       command: npm install
 `,
 		},
+		{
+			testName: "job with executor and working dir",
+			job: Job{
+				Name:             "job",
+				Executor:         "x",
+				WorkingDirectory: "dir",
+			},
+			expected: "executor: x\nworking_directory: dir\nsteps: []\n",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -458,6 +458,13 @@ func TestStep_YamlNode(t *testing.T) {
 			},
 			expected: "checkout\n",
 		}, {
+			testName: "checkout with path",
+			step: Step{
+				Type: Checkout,
+				Path: "subdir",
+			},
+			expected: "checkout:\n  path: subdir\n",
+		}, {
 			testName: "checkout with comment",
 			step: Step{
 				Type:    Checkout,

--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -110,11 +110,10 @@ jobs:
   test-node:
     # Install node dependencies and run tests
     executor: node/default
+    working_directory: ~/project/node-dir
     steps:
-      - checkout
-      - run:
-          name: Change into 'node-dir' directory
-          command: cd 'node-dir'
+      - checkout:
+          path: ~/project
       - node/install-packages:
           pkg-manager: npm
       - run:
@@ -124,11 +123,10 @@ jobs:
     # Install go modules and run tests
     docker:
       - image: cimg/go:1.20
+    working_directory: ~/project/go-dir
     steps:
-      - checkout
-      - run:
-          name: Change into 'go-dir' directory
-          command: cd 'go-dir'
+      - checkout:
+          path: ~/project
       - restore_cache:
           key: go-mod-{{ checksum "go.sum" }}
       - run:
@@ -339,11 +337,10 @@ jobs:
   test-python:
     # Install dependencies and run tests
     executor: python/default
+    working_directory: ~/project/x
     steps:
-      - checkout
-      - run:
-          name: Change into 'x' directory
-          command: cd 'x'
+      - checkout:
+          path: ~/project
       - python/install-packages:
           pkg-manager: poetry
       - run:

--- a/generation/internal/common.go
+++ b/generation/internal/common.go
@@ -4,25 +4,26 @@ import (
 	"fmt"
 	"github.com/CircleCI-Public/circleci-config/config"
 	"github.com/CircleCI-Public/circleci-config/labeling/labels"
-	"github.com/alessio/shellescape"
+	"path/filepath"
 )
 
-var checkoutStep = config.Step{Type: config.Checkout}
+const defaultCheckoutDir = "~/project"
 
-// initialSteps returns a checkout step and, if necessary cd step
-func initialSteps(depsLabel labels.Label) []config.Step {
-	steps := []config.Step{checkoutStep}
-
-	basePath := depsLabel.BasePath
-	if basePath != "." {
-		steps = append(steps, config.Step{
-			Type:    config.Run,
-			Name:    fmt.Sprintf("Change into '%s' directory", basePath),
-			Command: fmt.Sprintf("cd '%s'", shellescape.Quote(basePath)),
-		})
+func checkoutStep(depsLabel labels.Label) config.Step {
+	if depsLabel.BasePath == "." {
+		return config.Step{Type: config.Checkout}
 	}
+	return config.Step{
+		Type: config.Checkout,
+		Path: defaultCheckoutDir,
+	}
+}
 
-	return steps
+func workingDirectory(depsLabel labels.Label) string {
+	if depsLabel.BasePath == "." {
+		return "."
+	}
+	return filepath.Join(defaultCheckoutDir, depsLabel.BasePath)
 }
 
 const artifactsPath = "~/artifacts"

--- a/generation/internal/go.go
+++ b/generation/internal/go.go
@@ -10,8 +10,8 @@ import (
 func goInitialSteps(ls labels.LabelSet) []config.Step {
 	const goCacheKey = `go-mod-{{ checksum "go.sum" }}`
 
-	steps := initialSteps(ls[labels.DepsGo])
-	steps = append(steps, []config.Step{
+	return []config.Step{
+		checkoutStep(ls[labels.DepsGo]),
 		{
 			Type:     config.RestoreCache,
 			CacheKey: goCacheKey,
@@ -23,8 +23,7 @@ func goInitialSteps(ls labels.LabelSet) []config.Step {
 			Type:     config.SaveCache,
 			CacheKey: goCacheKey,
 			Path:     "/home/circleci/go/pkg/mod",
-		}}...)
-	return steps
+		}}
 }
 
 func goTestJob(ls labels.LabelSet) *Job {
@@ -41,10 +40,11 @@ func goTestJob(ls labels.LabelSet) *Job {
 
 	return &Job{
 		Job: config.Job{
-			Name:         "test-go",
-			Comment:      "Install go modules and run tests",
-			DockerImages: []string{"cimg/go:1.20"},
-			Steps:        steps,
+			Name:             "test-go",
+			Comment:          "Install go modules and run tests",
+			DockerImages:     []string{"cimg/go:1.20"},
+			WorkingDirectory: workingDirectory(ls[labels.DepsGo]),
+			Steps:            steps,
 		},
 		Type: TestJob,
 	}

--- a/generation/internal/python.go
+++ b/generation/internal/python.go
@@ -68,7 +68,7 @@ func poetrySteps(l labels.Label) []config.Step {
 }
 
 func pythonTestJob(ls labels.LabelSet) *Job {
-	steps := initialSteps(ls[labels.DepsPython])
+	steps := []config.Step{checkoutStep(ls[labels.DepsPython])}
 
 	// Support for different package managers
 	switch {
@@ -88,10 +88,11 @@ func pythonTestJob(ls labels.LabelSet) *Job {
 
 	return &Job{
 		Job: config.Job{
-			Name:     "test-python",
-			Comment:  "Install dependencies and run tests",
-			Executor: "python/default",
-			Steps:    steps,
+			Name:             "test-python",
+			Comment:          "Install dependencies and run tests",
+			Executor:         "python/default",
+			WorkingDirectory: workingDirectory(ls[labels.DepsPython]),
+			Steps:            steps,
 		},
 		Type: TestJob,
 		Orbs: map[string]string{

--- a/generation/internal/ruby.go
+++ b/generation/internal/ruby.go
@@ -18,13 +18,10 @@ func GenerateRubyJobs(ls labels.LabelSet) (jobs []*Job) {
 }
 
 func rubyInitialSteps(ls labels.LabelSet) []config.Step {
-	steps := initialSteps(ls[labels.DepsRuby])
-
-	steps = append(steps, config.Step{
-		Type:    config.OrbCommand,
-		Command: "ruby/install-deps",
-	})
-	return steps
+	return []config.Step{
+		checkoutStep(ls[labels.DepsRuby]),
+		{Type: config.OrbCommand, Command: "ruby/install-deps"},
+	}
 }
 
 const rubyOrb = "circleci/ruby@1.1.0"
@@ -54,10 +51,11 @@ func rspecJob(ls labels.LabelSet) *Job {
 
 	return &Job{
 		Job: config.Job{
-			Name:         "test-ruby",
-			Comment:      "Install gems, run rspec tests",
-			Steps:        steps,
-			DockerImages: images,
+			Name:             "test-ruby",
+			Comment:          "Install gems, run rspec tests",
+			Steps:            steps,
+			DockerImages:     images,
+			WorkingDirectory: workingDirectory(ls[labels.DepsRuby]),
 			Environment: map[string]string{
 				"RAILS_ENV": "test"},
 		},

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.20
 require gopkg.in/yaml.v3 v3.0.1
 
 require (
-	github.com/alessio/shellescape v1.4.1
 	github.com/go-git/go-git/v5 v5.7.0
 	github.com/google/go-cmp v0.5.9
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/ProtonMail/go-crypto v0.0.0-20230518184743-7afd39499903 h1:ZK3C5DtzV2
 github.com/ProtonMail/go-crypto v0.0.0-20230518184743-7afd39499903/go.mod h1:8TI4H3IbrackdNgv+92dI+rhpCaLqM0IfpgCgenFvRE=
 github.com/acomagu/bufpipe v1.0.4 h1:e3H4WUzM3npvo5uv95QuJM3cQspFNtFBzvJ2oNjKIDQ=
 github.com/acomagu/bufpipe v1.0.4/go.mod h1:mxdxdup/WdsKVreO5GpW4+M/1CE2sMG4jeGJ2sYmHc4=
-github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
-github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=


### PR DESCRIPTION
Instead of trying to `cd` into a dir or trying to set `pkg-dir` for orbs commands, set the working dir of the whole job, and only override the dir of the checkout step.

The go.mod/.sum changes are beacuse we can drop the shellscape dependency.

_Best reviewed commit-by-commit_