### PR TITLE
Handle python projects that have a manage.py file

### DIFF
--- a/cmd/inferconfig/testdata/expected/circleci-demo-python-django.yml
+++ b/cmd/inferconfig/testdata/expected/circleci-demo-python-django.yml
@@ -1,5 +1,5 @@
 # This config was automatically generated from your source code
-# Stacks detected: deps:python:.,package_manager:pipenv:.
+# Stacks detected: deps:python:.,file:manage.py:.,package_manager:pipenv:.
 version: 2.1
 orbs:
   python: circleci/python@2
@@ -13,9 +13,7 @@ jobs:
           pkg-manager: pipenv
       - run:
           name: Run tests
-          command: pipenv run pytest --junitxml=junit.xml
-      - store_test_results:
-          path: junit.xml
+          command: pipenv run python manage.py test
   deploy:
     # This is an example deploy job, not actually used by the workflow
     docker:

--- a/cmd/inferconfig/testdata/expected/circleci-demo-python-flask.yml
+++ b/cmd/inferconfig/testdata/expected/circleci-demo-python-flask.yml
@@ -1,5 +1,5 @@
 # This config was automatically generated from your source code
-# Stacks detected: deps:python:.
+# Stacks detected: deps:python:.,file:manage.py:.
 version: 2.1
 orbs:
   python: circleci/python@2
@@ -11,15 +11,9 @@ jobs:
       - checkout
       - python/install-packages:
           pkg-manager: pip
-      - python/install-packages:
-          args: pytest
-          pkg-manager: pip
-          pypi-cache: false
       - run:
           name: Run tests
-          command: pytest --junitxml=junit.xml
-      - store_test_results:
-          path: junit.xml
+          command: python manage.py test
   deploy:
     # This is an example deploy job, not actually used by the workflow
     docker:

--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -264,7 +264,6 @@ workflows:
 `,
 		},
 		{
-
 			testName: "python codebase with poetry package manager",
 			labels: labels.LabelSet{
 				labels.DepsPython: labels.Label{
@@ -348,6 +347,166 @@ jobs:
           command: poetry run pytest --junitxml=junit.xml
       - store_test_results:
           path: junit.xml
+  deploy:
+    # This is an example deploy job, not actually used by the workflow
+    docker:
+      - image: cimg/base:stable
+    steps:
+      # Replace this with steps to deploy to users
+      - run:
+          name: deploy
+          command: '#e.g. ./deploy.sh'
+workflows:
+  build-and-test:
+    jobs:
+      - test-python
+    # - deploy:
+    #     requires:
+    #       - test-python
+`,
+		},
+		{
+			testName: "python project with a manage.py file using poetry",
+			labels: labels.LabelSet{
+				labels.DepsPython: labels.Label{
+					Key:   labels.DepsPython,
+					Valid: true,
+					LabelData: labels.LabelData{
+						BasePath: ".",
+					},
+				},
+				labels.FileManagePy: labels.Label{
+					Key:       labels.FileManagePy,
+					Valid:     true,
+					LabelData: labels.LabelData{BasePath: "."},
+				},
+			},
+			expected: `# This config was automatically generated from your source code
+# Stacks detected: deps:python:.,file:manage.py:.
+version: 2.1
+orbs:
+  python: circleci/python@2
+jobs:
+  test-python:
+    # Install dependencies and run tests
+    executor: python/default
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: pip
+      - run:
+          name: Run tests
+          command: python manage.py test
+  deploy:
+    # This is an example deploy job, not actually used by the workflow
+    docker:
+      - image: cimg/base:stable
+    steps:
+      # Replace this with steps to deploy to users
+      - run:
+          name: deploy
+          command: '#e.g. ./deploy.sh'
+workflows:
+  build-and-test:
+    jobs:
+      - test-python
+    # - deploy:
+    #     requires:
+    #       - test-python
+`,
+		},
+		{
+			testName: "python project with a manage.py file using pipenv",
+			labels: labels.LabelSet{
+				labels.DepsPython: labels.Label{
+					Key:   labels.DepsPython,
+					Valid: true,
+					LabelData: labels.LabelData{
+						BasePath: ".",
+					},
+				},
+				labels.FileManagePy: labels.Label{
+					Key:       labels.FileManagePy,
+					Valid:     true,
+					LabelData: labels.LabelData{BasePath: "."},
+				},
+				labels.PackageManagerPipenv: labels.Label{
+					Key:       labels.PackageManagerPipenv,
+					Valid:     true,
+					LabelData: labels.LabelData{BasePath: "."},
+				},
+			},
+			expected: `# This config was automatically generated from your source code
+# Stacks detected: deps:python:.,file:manage.py:.,package_manager:pipenv:.
+version: 2.1
+orbs:
+  python: circleci/python@2
+jobs:
+  test-python:
+    # Install dependencies and run tests
+    executor: python/default
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: pipenv
+      - run:
+          name: Run tests
+          command: pipenv run python manage.py test
+  deploy:
+    # This is an example deploy job, not actually used by the workflow
+    docker:
+      - image: cimg/base:stable
+    steps:
+      # Replace this with steps to deploy to users
+      - run:
+          name: deploy
+          command: '#e.g. ./deploy.sh'
+workflows:
+  build-and-test:
+    jobs:
+      - test-python
+    # - deploy:
+    #     requires:
+    #       - test-python
+`,
+		},
+		{
+			testName: "python project with a manage.py file using poetry",
+			labels: labels.LabelSet{
+				labels.DepsPython: labels.Label{
+					Key:   labels.DepsPython,
+					Valid: true,
+					LabelData: labels.LabelData{
+						BasePath: ".",
+					},
+				},
+				labels.FileManagePy: labels.Label{
+					Key:       labels.FileManagePy,
+					Valid:     true,
+					LabelData: labels.LabelData{BasePath: "."},
+				},
+				labels.PackageManagerPoetry: labels.Label{
+					Key:       labels.PackageManagerPoetry,
+					Valid:     true,
+					LabelData: labels.LabelData{BasePath: "."},
+				},
+			},
+			expected: `# This config was automatically generated from your source code
+# Stacks detected: deps:python:.,file:manage.py:.,package_manager:poetry:.
+version: 2.1
+orbs:
+  python: circleci/python@2
+jobs:
+  test-python:
+    # Install dependencies and run tests
+    executor: python/default
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: poetry
+      - run:
+          name: Run tests
+          command: poetry run python manage.py test
   deploy:
     # This is an example deploy job, not actually used by the workflow
     docker:

--- a/generation/internal/python.go
+++ b/generation/internal/python.go
@@ -7,8 +7,8 @@ import (
 
 const pythonOrb = "circleci/python@2"
 
-func pipSteps(l labels.Label) []config.Step {
-	return []config.Step{
+func pipSteps(l labels.Label, hasManagePy bool) []config.Step {
+	steps := []config.Step{
 		{
 			Type:    config.OrbCommand,
 			Command: "python/install-packages",
@@ -16,6 +16,18 @@ func pipSteps(l labels.Label) []config.Step {
 				"pkg-manager": "pip",
 			},
 		},
+	}
+
+	if hasManagePy {
+		steps = append(steps, config.Step{
+			Name:    "Run tests",
+			Type:    config.Run,
+			Command: "python manage.py test",
+		})
+		return steps
+	}
+
+	steps = append(steps, []config.Step{
 		{
 			Type:    config.OrbCommand,
 			Command: "python/install-packages",
@@ -29,12 +41,13 @@ func pipSteps(l labels.Label) []config.Step {
 			Name:    "Run tests",
 			Type:    config.Run,
 			Command: "pytest --junitxml=junit.xml",
-		},
-	}
+		}}...)
+
+	return steps
 }
 
-func pipenvSteps(l labels.Label) []config.Step {
-	return []config.Step{
+func pipenvSteps(l labels.Label, hasManagePy bool) []config.Step {
+	steps := []config.Step{
 		{
 			Type:    config.OrbCommand,
 			Command: "python/install-packages",
@@ -42,16 +55,28 @@ func pipenvSteps(l labels.Label) []config.Step {
 				"pkg-manager": "pipenv",
 			},
 		},
-		{
+	}
+
+	if hasManagePy {
+		steps = append(steps, config.Step{
 			Name:    "Run tests",
 			Type:    config.Run,
-			Command: "pipenv run pytest --junitxml=junit.xml",
-		},
+			Command: "pipenv run python manage.py test",
+		})
+		return steps
 	}
+
+	steps = append(steps, config.Step{
+		Name:    "Run tests",
+		Type:    config.Run,
+		Command: "pipenv run pytest --junitxml=junit.xml",
+	})
+
+	return steps
 }
 
-func poetrySteps(l labels.Label) []config.Step {
-	return []config.Step{
+func poetrySteps(l labels.Label, hasManagerPy bool) []config.Step {
+	steps := []config.Step{
 		{
 			Type:    config.OrbCommand,
 			Command: "python/install-packages",
@@ -59,32 +84,47 @@ func poetrySteps(l labels.Label) []config.Step {
 				"pkg-manager": "poetry",
 			},
 		},
-		{
+	}
+
+	if hasManagerPy {
+		steps = append(steps, config.Step{
 			Name:    "Run tests",
 			Type:    config.Run,
-			Command: "poetry run pytest --junitxml=junit.xml",
-		},
+			Command: "poetry run python manage.py test",
+		})
+		return steps
 	}
+
+	steps = append(steps, config.Step{
+		Name:    "Run tests",
+		Type:    config.Run,
+		Command: "poetry run pytest --junitxml=junit.xml",
+	})
+
+	return steps
 }
 
 func pythonTestJob(ls labels.LabelSet) *Job {
 	steps := []config.Step{checkoutStep(ls[labels.DepsPython])}
+	hasManagePy := ls[labels.FileManagePy].Valid
 
 	// Support for different package managers
 	switch {
 	case ls[labels.PackageManagerPipenv].Valid:
-		steps = append(steps, pipenvSteps(ls[labels.PackageManagerPipenv])...)
+		steps = append(steps, pipenvSteps(ls[labels.PackageManagerPipenv], hasManagePy)...)
 	case ls[labels.PackageManagerPoetry].Valid:
-		steps = append(steps, poetrySteps(ls[labels.PackageManagerPoetry])...)
+		steps = append(steps, poetrySteps(ls[labels.PackageManagerPoetry], hasManagePy)...)
 	default:
-		steps = append(steps, pipSteps(ls[labels.DepsPython])...)
+		steps = append(steps, pipSteps(ls[labels.DepsPython], hasManagePy)...)
 	}
 
-	// Store test results
-	steps = append(steps, config.Step{
-		Type: config.StoreTestResults,
-		Path: "junit.xml",
-	})
+	if !hasManagePy {
+		// Store test results
+		steps = append(steps, config.Step{
+			Type: config.StoreTestResults,
+			Path: "junit.xml",
+		})
+	}
 
 	return &Job{
 		Job: config.Job{

--- a/labeling/internal/python.go
+++ b/labeling/internal/python.go
@@ -22,6 +22,8 @@ var possiblePythonFiles = append(
 	append(
 		[]string{
 			"requirements.txt",
+			"setup.py",
+			"manage.py",
 		},
 		pipenvFiles...,
 	),
@@ -54,6 +56,15 @@ var PythonRules = []labels.Rule{
 		poetryLock, _ := c.FindFile(poetryFiles...)
 		label.Valid = poetryLock != ""
 		label.BasePath = path.Dir(poetryLock)
+		return label, nil
+	},
+	func(c codebase.Codebase, ls *labels.LabelSet) (labels.Label, error) {
+		label := labels.Label{
+			Key: labels.FileManagePy,
+		}
+		managePyPath, _ := c.FindFile("manage.py")
+		label.Valid = managePyPath != ""
+		label.BasePath = path.Dir(managePyPath)
 		return label, nil
 	},
 }

--- a/labeling/labeling_test.go
+++ b/labeling/labeling_test.go
@@ -408,6 +408,28 @@ func TestCodebase_ApplyRules_Python(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "manage.py => file:manage.py",
+			files: map[string]string{
+				"manage.py": "mylib==1.0",
+			},
+			expectedLabels: []labels.Label{
+				{
+					Key: labels.DepsPython,
+					LabelData: labels.LabelData{
+						BasePath: ".",
+					},
+					Valid: true,
+				},
+				{
+					Key: labels.FileManagePy,
+					LabelData: labels.LabelData{
+						BasePath: ".",
+					},
+					Valid: true,
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/labeling/labels/labels.go
+++ b/labeling/labels/labels.go
@@ -18,6 +18,7 @@ const (
 	PackageManagerPoetry = "package_manager:poetry"
 	PackageManagerYarn   = "package_manager:yarn"
 	TestJest             = "test:jest"
+	FileManagePy         = "file:manage.py"
 )
 
 type LabelData struct {


### PR DESCRIPTION
Django and flask projects usually would have this file and use it to run tests.

Decided to create a new kind of file label since in this case we were going to be
using a single file to determine which test command to run.
