### PR TITLE
Parse GemSpec for finding ruby dependencies

### DIFF
--- a/labeling/codebase/localcodebase.go
+++ b/labeling/codebase/localcodebase.go
@@ -1,7 +1,7 @@
 package codebase
 
 import (
-	"fmt"
+	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -11,6 +11,8 @@ import (
 
 const maxFiles = 250000
 const defaultMaxDepth = 3
+
+var NotFoundError = errors.New("not found")
 
 // LocalCodebase is a Codebase for files available on local disk
 type LocalCodebase struct {
@@ -41,7 +43,7 @@ func (c LocalCodebase) FindFileMatching(
 		}
 	}
 
-	return "", fmt.Errorf("not found")
+	return "", NotFoundError
 
 }
 

--- a/labeling/labeling_test.go
+++ b/labeling/labeling_test.go
@@ -1,11 +1,11 @@
 package labeling
 
 import (
-	"fmt"
 	"path/filepath"
 	"reflect"
 	"testing"
 
+	"github.com/CircleCI-Public/circleci-config/labeling/codebase"
 	"github.com/CircleCI-Public/circleci-config/labeling/internal"
 	"github.com/CircleCI-Public/circleci-config/labeling/labels"
 )
@@ -26,7 +26,7 @@ func (c fakeCodebase) FindFileMatching(predicate func(string) bool, globs ...str
 			}
 		}
 	}
-	return "", fmt.Errorf("not found")
+	return "", codebase.NotFoundError
 }
 
 func (c fakeCodebase) FindFile(globs ...string) (path string, err error) {
@@ -38,7 +38,7 @@ func (c fakeCodebase) ReadFile(path string) (contents []byte, err error) {
 	if contentString != "" {
 		return []byte(contentString), nil
 	}
-	return nil, fmt.Errorf("not found")
+	return nil, codebase.NotFoundError
 }
 
 func TestCodebase_ApplyAllRules(t *testing.T) {

--- a/labeling/ruby_test.go
+++ b/labeling/ruby_test.go
@@ -69,6 +69,23 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Ruby gemspec file",
+			files: map[string]string{
+				"mygem.gemspec": rubyGemSpecFile,
+			},
+			expectedLabels: []labels.Label{
+				{
+					Key: labels.DepsRuby,
+					LabelData: labels.LabelData{
+						BasePath: ".",
+						Dependencies: map[string]string{
+							"rake": "true",
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -138,3 +155,12 @@ ruby '1.9.3', :engine => 'jruby', :engine_version => '1.6.7'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.1'`
+
+const rubyGemSpecFile = `
+Gem::Specification.new do |spec|
+  spec.name        = 'mygem'
+  spec.version     = Mygem::VERSION
+  spec.platform    = Gem::Platform::RUBY
+  spec.add_development_dependency('rake', '13.0.6')
+end
+`


### PR DESCRIPTION
Rather than just checking for a Gemfile, we should also parse a GemSpec file for developer dependencies. 

Also support general rake tests, rather than just rspec.

CVL-522