### PR TITLE
Use regular bundle install command for gemspec projects

### DIFF
--- a/cmd/inferconfig/testdata/expected/circleci-demo-ruby-rails.yml
+++ b/cmd/inferconfig/testdata/expected/circleci-demo-ruby-rails.yml
@@ -3,7 +3,7 @@
 version: 2.1
 orbs:
   node: circleci/node@5
-  ruby: circleci/ruby@1.1.0
+  ruby: circleci/ruby@2.0.1
 jobs:
   test-node:
     # Install node dependencies and run tests

--- a/generation/internal/ruby.go
+++ b/generation/internal/ruby.go
@@ -22,10 +22,18 @@ func GenerateRubyJobs(ls labels.LabelSet) (jobs []*Job) {
 }
 
 func rubyInitialSteps(ls labels.LabelSet) []config.Step {
-	return []config.Step{
-		checkoutStep(ls[labels.DepsRuby]),
-		{Type: config.OrbCommand, Command: "ruby/install-deps"},
+
+	checkout := checkoutStep(ls[labels.DepsRuby])
+
+	installDeps := config.Step{Type: config.OrbCommand, Command: "ruby/install-deps"}
+
+	if !ls[labels.DepsRuby].LabelData.HasLockFile && ls[labels.PackageManagerGemspec].Valid == true {
+		installDeps.Parameters = config.OrbCommandParameters{
+			"override-cache-file": ls[labels.PackageManagerGemspec].Path,
+		}
+
 	}
+	return []config.Step{checkout, installDeps}
 }
 
 const rubyOrb = "circleci/ruby@1.1.0"

--- a/generation/internal/ruby.go
+++ b/generation/internal/ruby.go
@@ -24,9 +24,10 @@ func rubyInitialSteps(ls labels.LabelSet) []config.Step {
 	checkout := checkoutStep(ls[labels.DepsRuby])
 
 	installDeps := config.Step{Type: config.OrbCommand, Command: "ruby/install-deps"}
+
+	// ruby orb requires Gemfile.lockfile, so revert to basic bundle command when not found
 	if !ls[labels.DepsRuby].LabelData.HasLockFile && ls[labels.PackageManagerGemspec].Valid == true {
 		installDeps = config.Step{Type: config.Run, Command: "bundle install"}
-
 	}
 	return []config.Step{checkout, installDeps}
 }

--- a/generation/internal/ruby.go
+++ b/generation/internal/ruby.go
@@ -10,12 +10,10 @@ func GenerateRubyJobs(ls labels.LabelSet) (jobs []*Job) {
 		return nil
 	}
 
-	if ls[labels.DepsRuby].Dependencies["rspec"] == "true" {
-		jobs = append(jobs, rspecJob(ls))
-	}
-
 	if ls[labels.DepsRuby].Dependencies["rake"] == "true" {
 		jobs = append(jobs, rakeJob(ls))
+	} else if ls[labels.DepsRuby].Dependencies["rspec"] == "true" {
+		jobs = append(jobs, rspecJob(ls))
 	}
 
 	return jobs

--- a/generation/internal/ruby.go
+++ b/generation/internal/ruby.go
@@ -10,13 +10,21 @@ func GenerateRubyJobs(ls labels.LabelSet) (jobs []*Job) {
 		return nil
 	}
 
-	if ls[labels.DepsRuby].Dependencies["rake"] == "true" {
+	if hasGem(ls, "rake") {
 		jobs = append(jobs, rakeJob(ls))
-	} else if ls[labels.DepsRuby].Dependencies["rspec"] == "true" {
+	} else if hasGem(ls, "rspec") {
 		jobs = append(jobs, rspecJob(ls))
 	}
-
 	return jobs
+}
+
+func hasGem(ls labels.LabelSet, gem string) bool {
+	for _, label := range []string{labels.DepsRuby, labels.PackageManagerGemspec} {
+		if ls[label].Valid == true && ls[label].LabelData.Dependencies[gem] != "" {
+			return true
+		}
+	}
+	return false
 }
 
 func rubyInitialSteps(ls labels.LabelSet) []config.Step {

--- a/generation/internal/ruby.go
+++ b/generation/internal/ruby.go
@@ -36,7 +36,7 @@ func rubyInitialSteps(ls labels.LabelSet) []config.Step {
 	return []config.Step{checkout, installDeps}
 }
 
-const rubyOrb = "circleci/ruby@1.1.0"
+const rubyOrb = "circleci/ruby@2.0.1"
 const postgresImage = "circleci/postgres:9.5-alpine"
 
 func rspecJob(ls labels.LabelSet) *Job {

--- a/generation/internal/ruby.go
+++ b/generation/internal/ruby.go
@@ -24,11 +24,8 @@ func rubyInitialSteps(ls labels.LabelSet) []config.Step {
 	checkout := checkoutStep(ls[labels.DepsRuby])
 
 	installDeps := config.Step{Type: config.OrbCommand, Command: "ruby/install-deps"}
-
 	if !ls[labels.DepsRuby].LabelData.HasLockFile && ls[labels.PackageManagerGemspec].Valid == true {
-		installDeps.Parameters = config.OrbCommandParameters{
-			"override-cache-file": ls[labels.PackageManagerGemspec].Path,
-		}
+		installDeps = config.Step{Type: config.Run, Command: "bundle install"}
 
 	}
 	return []config.Step{checkout, installDeps}

--- a/generation/internal/ruby_test.go
+++ b/generation/internal/ruby_test.go
@@ -110,11 +110,8 @@ func Test_rubyInitialSteps(t *testing.T) {
 			},
 			want: []config.Step{
 				{Type: config.Checkout},
-				{Type: config.OrbCommand,
-					Command: "ruby/install-deps",
-					Parameters: config.OrbCommandParameters{
-						"override-cache-file": "./my.gemspec",
-					},
+				{Type: config.Run,
+					Command: "bundle install",
 				},
 			},
 		},

--- a/generation/internal/ruby_test.go
+++ b/generation/internal/ruby_test.go
@@ -53,20 +53,6 @@ func Test_rubyImageVersion(t *testing.T) {
 	}
 }
 
-// func Test_rubyInitialSteps(t *testing.T) {
-//	tests := []struct{
-//		name string
-//		labels labels.LabelSet
-//		[]config.Step
-//	}{
-
-//	}
-//	for _, tt ::= range tests  {
-
-//	}
-
-// }
-
 func Test_rubyInitialSteps(t *testing.T) {
 	tests := []struct {
 		name string

--- a/generation/internal/ruby_test.go
+++ b/generation/internal/ruby_test.go
@@ -1,7 +1,6 @@
 package internal
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -89,9 +88,6 @@ func Test_rubyInitialSteps(t *testing.T) {
 				labels.PackageManagerGemspec: labels.Label{
 					Key:   labels.PackageManagerGemspec,
 					Valid: true,
-					LabelData: labels.LabelData{
-						Path: "./my.gemspec",
-					},
 				},
 			},
 			want: []config.Step{
@@ -106,8 +102,6 @@ func Test_rubyInitialSteps(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := rubyInitialSteps(tt.ls); !reflect.DeepEqual(got, tt.want) {
-				fmt.Println("want", tt.want)
-				fmt.Println("got", got)
 				t.Errorf("rubyInitialSteps() = %v, want %v", got, tt.want)
 			}
 		})

--- a/labeling/internal/common.go
+++ b/labeling/internal/common.go
@@ -1,0 +1,8 @@
+package internal
+
+import "github.com/CircleCI-Public/circleci-config/labeling/codebase"
+
+func hasPath(c codebase.Codebase, path string) bool {
+	foundPath, _ := c.FindFile(path)
+	return foundPath != ""
+}

--- a/labeling/internal/ruby.go
+++ b/labeling/internal/ruby.go
@@ -41,6 +41,7 @@ var RubyRules = []labels.Rule{
 		if gemspecPath != "" {
 			label.Valid = true
 			label.BasePath = path.Dir(gemspecPath)
+			label.Path = gemspecPath
 			err = readDepsFile(c, label.Dependencies, gemspecPath)
 			if err != nil {
 				return label, err

--- a/labeling/internal/ruby.go
+++ b/labeling/internal/ruby.go
@@ -41,7 +41,6 @@ var RubyRules = []labels.Rule{
 		if gemspecPath != "" {
 			label.Valid = true
 			label.BasePath = path.Dir(gemspecPath)
-			label.Path = gemspecPath
 			err = readDepsFile(c, label.Dependencies, gemspecPath)
 			if err != nil {
 				return label, err

--- a/labeling/labels/labels.go
+++ b/labeling/labels/labels.go
@@ -27,6 +27,7 @@ type LabelData struct {
 	Dependencies map[string]string
 	Tasks        map[string]string
 	HasLockFile  bool
+	Path         string
 }
 
 // Label is the result of applying a Rule

--- a/labeling/labels/labels.go
+++ b/labeling/labels/labels.go
@@ -27,7 +27,6 @@ type LabelData struct {
 	Dependencies map[string]string
 	Tasks        map[string]string
 	HasLockFile  bool
-	Path         string
 }
 
 // Label is the result of applying a Rule

--- a/labeling/labels/labels.go
+++ b/labeling/labels/labels.go
@@ -9,16 +9,17 @@ import (
 )
 
 const (
-	ArtifactGoExecutable = "artifact:go-executable"
-	DepsGo               = "deps:go"
-	DepsNode             = "deps:node"
-	DepsPython           = "deps:python"
-	DepsRuby             = "deps:ruby"
-	PackageManagerPipenv = "package_manager:pipenv"
-	PackageManagerPoetry = "package_manager:poetry"
-	PackageManagerYarn   = "package_manager:yarn"
-	TestJest             = "test:jest"
-	FileManagePy         = "file:manage.py"
+	ArtifactGoExecutable  = "artifact:go-executable"
+	DepsGo                = "deps:go"
+	DepsNode              = "deps:node"
+	DepsPython            = "deps:python"
+	DepsRuby              = "deps:ruby"
+	PackageManagerPipenv  = "package_manager:pipenv"
+	PackageManagerPoetry  = "package_manager:poetry"
+	PackageManagerYarn    = "package_manager:yarn"
+	PackageManagerGemspec = "package_manager:gemspec"
+	TestJest              = "test:jest"
+	FileManagePy          = "file:manage.py"
 )
 
 type LabelData struct {

--- a/labeling/ruby_test.go
+++ b/labeling/ruby_test.go
@@ -12,11 +12,13 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 		name           string
 		files          map[string]string
 		expectedLabels []labels.Label
+		hasLockFile    bool
 	}{
 		{
 			name: "Ruby version",
 			files: map[string]string{
-				"Gemfile": rubyGemfile,
+				"Gemfile":      rubyGemfile,
+				"Gemfile.lock": "<lockfile contents>",
 			},
 
 			expectedLabels: []labels.Label{
@@ -27,6 +29,7 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 						Dependencies: map[string]string{
 							"ruby": "2.7.8",
 						},
+						HasLockFile: true,
 					},
 				},
 			},
@@ -76,7 +79,7 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 			},
 			expectedLabels: []labels.Label{
 				{
-					Key: labels.DepsRuby,
+					Key: labels.PackageManagerGemspec,
 					LabelData: labels.LabelData{
 						BasePath: ".",
 						Dependencies: map[string]string{
@@ -98,9 +101,16 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 					LabelData: labels.LabelData{
 						BasePath: ".",
 						Dependencies: map[string]string{
-							"rake": "true",
 							"ruby": "2.7.8",
 						},
+					},
+				},
+				{
+					Key: labels.PackageManagerGemspec,
+					LabelData: labels.LabelData{
+						BasePath: ".",
+						Dependencies: map[string]string{
+							"rake": "true"},
 					},
 				},
 			},

--- a/labeling/ruby_test.go
+++ b/labeling/ruby_test.go
@@ -82,6 +82,7 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 					Key: labels.PackageManagerGemspec,
 					LabelData: labels.LabelData{
 						BasePath: ".",
+						Path:     "mygem.gemspec",
 						Dependencies: map[string]string{
 							"rake": "true",
 						},
@@ -109,6 +110,7 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 					Key: labels.PackageManagerGemspec,
 					LabelData: labels.LabelData{
 						BasePath: ".",
+						Path:     "mygem.gemspec",
 						Dependencies: map[string]string{
 							"rake": "true"},
 					},

--- a/labeling/ruby_test.go
+++ b/labeling/ruby_test.go
@@ -82,7 +82,6 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 					Key: labels.PackageManagerGemspec,
 					LabelData: labels.LabelData{
 						BasePath: ".",
-						Path:     "mygem.gemspec",
 						Dependencies: map[string]string{
 							"rake": "true",
 						},
@@ -110,7 +109,6 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 					Key: labels.PackageManagerGemspec,
 					LabelData: labels.LabelData{
 						BasePath: ".",
-						Path:     "mygem.gemspec",
 						Dependencies: map[string]string{
 							"rake": "true"},
 					},


### PR DESCRIPTION
The ruby orb expects a Gemfile.lock, and tries to install with the `--deployment` option, which is not compatible for projects that rely on gemspec.

For these projects, fall back to using regular "bundle install" command.

CVL-522