### PR TITLE
Install jest-junit with the --ignore-workspace-root-check flag

### DIFF
--- a/generation/internal/node.go
+++ b/generation/internal/node.go
@@ -89,7 +89,7 @@ func nodeTestJob(ls labels.LabelSet) *Job {
 		if packageManager == "yarn" {
 			steps = append(steps, config.Step{
 				Type:    config.Run,
-				Command: "yarn add jest-junit",
+				Command: "yarn add jest-junit --ignore-workspace-root-check",
 			})
 		} else {
 			steps = append(steps, config.Step{


### PR DESCRIPTION
Should fix the error causing the build to fail at the `jest-junit` install step https://app.circleci.com/pipelines/github/polymeris-test-org/flipper/1/workflows/f6ad073b-2789-4321-816d-820f5dbddecc/jobs/2/parallel-runs/0/steps/0-108
