### PR TITLE
Basic Rust inference

### DIFF
--- a/cmd/inferconfig/inferconfig_test.go
+++ b/cmd/inferconfig/inferconfig_test.go
@@ -25,6 +25,8 @@ func TestInferConfig(t *testing.T) {
 		{url: "https://github.com/CircleCI-Public/circleci-demo-python-flask"},
 		{url: "https://github.com/CircleCI-Public/circleci-demo-python-django"},
 		{url: "https://github.com/CircleCI-Public/circleci-demo-ruby-rails"},
+		// There is no "demo" for rust, but the rust-orb repo contains a sample dir
+		{url: "https://github.com/CircleCI-Public/rust-orb"},
 	}
 
 	for _, tt := range tests {

--- a/cmd/inferconfig/testdata/expected/rust-orb.yml
+++ b/cmd/inferconfig/testdata/expected/rust-orb.yml
@@ -1,0 +1,30 @@
+# This config was automatically generated from your source code
+# Stacks detected: deps:rust:sample
+version: 2.1
+orbs:
+  rust: circleci/rust@1.6.0
+jobs:
+  test-rust:
+    # Run tests using the rust orb
+    executor: rust/default
+    working_directory: ~/project/sample
+    steps:
+      - checkout:
+          path: ~/project
+      - rust/test
+  deploy:
+    # This is an example deploy job, not actually used by the workflow
+    docker:
+      - image: cimg/base:stable
+    steps:
+      # Replace this with steps to deploy to users
+      - run:
+          name: deploy
+          command: '#e.g. ./deploy.sh'
+workflows:
+  build-and-test:
+    jobs:
+      - test-rust
+    # - deploy:
+    #     requires:
+    #       - test-rust

--- a/generation/generation.go
+++ b/generation/generation.go
@@ -12,5 +12,6 @@ func GenerateConfig(labels labels.LabelSet) config.Config {
 	generatedJobs = append(generatedJobs, internal.GenerateGoJobs(labels)...)
 	generatedJobs = append(generatedJobs, internal.GeneratePythonJobs(labels)...)
 	generatedJobs = append(generatedJobs, internal.GenerateRubyJobs(labels)...)
+	generatedJobs = append(generatedJobs, internal.GenerateRustJobs(labels)...)
 	return internal.BuildConfig(labels, generatedJobs)
 }

--- a/generation/internal/rust.go
+++ b/generation/internal/rust.go
@@ -1,0 +1,41 @@
+package internal
+
+import (
+	"github.com/CircleCI-Public/circleci-config/config"
+	"github.com/CircleCI-Public/circleci-config/labeling/labels"
+)
+
+const rustOrb = "circleci/rust@1.6.0"
+
+func rustInitialSteps(ls labels.LabelSet) []config.Step {
+	return []config.Step{checkoutStep(ls[labels.DepsRust])}
+}
+
+func rustTestJob(ls labels.LabelSet) *Job {
+	steps := rustInitialSteps(ls)
+
+	steps = append(steps, config.Step{
+		Type:    config.OrbCommand,
+		Command: "rust/test",
+	})
+
+	return &Job{
+		Job: config.Job{
+			Name:             "test-rust",
+			Comment:          "Run tests using the rust orb",
+			Executor:         "rust/default",
+			WorkingDirectory: workingDirectory(ls[labels.DepsRust]),
+			Steps:            steps,
+		},
+		Orbs: map[string]string{"rust": rustOrb},
+		Type: TestJob,
+	}
+}
+
+func GenerateRustJobs(ls labels.LabelSet) (jobs []*Job) {
+	if !ls[labels.DepsRust].Valid {
+		return nil
+	}
+
+	return append(jobs, rustTestJob(ls))
+}

--- a/labeling/internal/rust.go
+++ b/labeling/internal/rust.go
@@ -1,0 +1,17 @@
+package internal
+
+import (
+	"github.com/CircleCI-Public/circleci-config/labeling/codebase"
+	"github.com/CircleCI-Public/circleci-config/labeling/labels"
+	"path"
+)
+
+var RustRules = []labels.Rule{
+	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {
+		label.Key = labels.DepsRust
+		cargoTomlFile, err := c.FindFile("Cargo.toml", "cargo.toml")
+		label.Valid = cargoTomlFile != ""
+		label.BasePath = path.Dir(cargoTomlFile)
+		return label, err
+	},
+}

--- a/labeling/labeling.go
+++ b/labeling/labeling.go
@@ -32,6 +32,7 @@ func ApplyAllRules(c codebase.Codebase) labels.LabelSet {
 		internal.GoRules,
 		internal.PythonRules,
 		internal.RubyRules,
+		internal.RustRules,
 		// Add other stacks here
 	}
 

--- a/labeling/labeling_test.go
+++ b/labeling/labeling_test.go
@@ -50,9 +50,10 @@ func TestCodebase_ApplyAllRules(t *testing.T) {
 		{
 			name: "All rules apply",
 			files: map[string]string{
-				"go.mod":       "",
-				"package.json": `{"devDependencies":{"jest": "version"}}`,
-				"cmd/cmd.go":   "package main",
+				"go.mod":              "",
+				"package.json":        `{"devDependencies":{"jest": "version"}}`,
+				"cmd/cmd.go":          "package main",
+				"rust-dir/Cargo.toml": "",
 			},
 			expectedLabels: []labels.Label{
 				{
@@ -72,6 +73,11 @@ func TestCodebase_ApplyAllRules(t *testing.T) {
 				}, {
 					Key:       labels.ArtifactGoExecutable,
 					LabelData: labels.LabelData{},
+				}, {
+					Key: labels.DepsRust,
+					LabelData: labels.LabelData{
+						BasePath: "rust-dir",
+					},
 				},
 			},
 		},

--- a/labeling/labels/labels.go
+++ b/labeling/labels/labels.go
@@ -10,10 +10,12 @@ import (
 
 const (
 	ArtifactGoExecutable  = "artifact:go-executable"
+	ArtifactRustCrate     = "artifact:rust-crate"
 	DepsGo                = "deps:go"
 	DepsNode              = "deps:node"
 	DepsPython            = "deps:python"
 	DepsRuby              = "deps:ruby"
+	DepsRust              = "deps:rust"
 	PackageManagerPipenv  = "package_manager:pipenv"
 	PackageManagerPoetry  = "package_manager:poetry"
 	PackageManagerYarn    = "package_manager:yarn"


### PR DESCRIPTION
Note I only implemented enough to run `cargo test`.

We could consider parsing the `Cargo.toml` file and e.g. building executable, packaging crates, etc.

There is also no "store test results", as the rust orb doesn't provide it out of the box. We should explore alternatives to produce junit.xml files.