### PR TITLE
Trim extra whitespace from ruby version

### DIFF
--- a/labeling/internal/ruby.go
+++ b/labeling/internal/ruby.go
@@ -62,6 +62,7 @@ func readDepsFile(c codebase.Codebase, deps map[string]string, filePath string) 
 			version := strings.Split(line, ",")[0]
 			version = strings.SplitAfter(version, "ruby ")[1]
 			version = strings.ReplaceAll(version, "'", "")
+			version = strings.TrimSpace(version)
 			deps["ruby"] = version
 		}
 

--- a/labeling/ruby_test.go
+++ b/labeling/ruby_test.go
@@ -35,6 +35,26 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 			},
 		},
 		{
+			name: "Ruby version w/ extra trailing whitespace",
+			files: map[string]string{
+				"Gemfile":      "ruby '2.7.8'\r",
+				"Gemfile.lock": "<lockfile contents>",
+			},
+
+			expectedLabels: []labels.Label{
+				{
+					Key: labels.DepsRuby,
+					LabelData: labels.LabelData{
+						BasePath: ".",
+						Dependencies: map[string]string{
+							"ruby": "2.7.8",
+						},
+						HasLockFile: true,
+					},
+				},
+			},
+		},
+		{
 			name: "Ruby version w/ rspec, pg",
 			files: map[string]string{
 				"Gemfile": rubyGemfileWithRailsRSpec,


### PR DESCRIPTION
We parse the Gemfile to determine the ruby version to use in the config. If there is a ‘\r' on the line where we parse the ruby version, the config will incorrectly include that whitespace character.

CVL-539