### PR TITLE
Check for all forms of gemspec

### DIFF
--- a/labeling/internal/ruby.go
+++ b/labeling/internal/ruby.go
@@ -56,6 +56,7 @@ func readDepsFile(c codebase.Codebase, deps map[string]string, filePath string) 
 	if err != nil {
 		return err
 	}
+
 	for _, line := range strings.Split(string(fileContents), "\n") {
 		line = strings.ReplaceAll(line, "\"", "'")
 		if strings.HasPrefix(line, "ruby ") {
@@ -66,24 +67,28 @@ func readDepsFile(c codebase.Codebase, deps map[string]string, filePath string) 
 			deps["ruby"] = version
 		}
 
-		if strings.Contains(line, "gem 'rspec-rails'") ||
-			strings.Contains(line, "gem 'rspec'") {
-			deps["rspec"] = "true"
+		gems := map[string]string{
+			"rspec-rails":           "rspec",
+			"rspec":                 "rspec",
+			"rspec_junit_formatter": "rspec_junit_formatter",
+			"rake":                  "rake",
+			"pg":                    "pg",
 		}
-
-		if strings.Contains(line, "gem 'rspec_junit_formatter'") ||
-			strings.Contains(line, "development_dependency('rspec_junit_formatter'") {
-			deps["rspec_junit_formatter"] = "true"
-		}
-
-		if strings.Contains(line, "development_dependency('rake'") ||
-			strings.Contains(line, "gem 'rake'") {
-			deps["rake"] = "true"
-		}
-
-		if strings.Contains(line, "gem 'pg'") {
-			deps["pg"] = "true"
+		for k, v := range gems {
+			if hasGem(line, k) {
+				deps[v] = "true"
+			}
 		}
 	}
 	return nil
+}
+
+func hasGem(line string, gem string) bool {
+	forms := []string{"gem '", "development_dependency '", "development_dependency('"}
+	for _, f := range forms {
+		if strings.Contains(line, f+gem) {
+			return true
+		}
+	}
+	return false
 }

--- a/labeling/ruby_test.go
+++ b/labeling/ruby_test.go
@@ -29,6 +29,7 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 						BasePath: ".",
 						Dependencies: map[string]string{
 							"ruby":                  "2.7.8",
+							"rspec":                 "true",
 							"rspec_junit_formatter": "true",
 						},
 						HasLockFile: true,
@@ -106,7 +107,25 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 						BasePath: ".",
 						Dependencies: map[string]string{
 							"rake":                  "true",
+							"rspec":                 "true",
 							"rspec_junit_formatter": "true",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Ruby gemspec file - no parens",
+			files: map[string]string{
+				"mygem.gemspec": rubyGemSpecFileNoParens,
+			},
+			expectedLabels: []labels.Label{
+				{
+					Key: labels.PackageManagerGemspec,
+					LabelData: labels.LabelData{
+						BasePath: ".",
+						Dependencies: map[string]string{
+							"rake": "true",
 						},
 					},
 				},
@@ -125,6 +144,7 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 						BasePath: ".",
 						Dependencies: map[string]string{
 							"ruby":                  "2.7.8",
+							"rspec":                 "true",
 							"rspec_junit_formatter": "true",
 						},
 					},
@@ -135,6 +155,7 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 						BasePath: ".",
 						Dependencies: map[string]string{
 							"rake":                  "true",
+							"rspec":                 "true",
 							"rspec_junit_formatter": "true",
 						},
 					},
@@ -217,5 +238,14 @@ Gem::Specification.new do |spec|
   spec.platform    = Gem::Platform::RUBY
   spec.add_development_dependency('rake', '13.0.6')
   spec.add_development_dependency('rspec_junit_formatter')
+end
+`
+
+const rubyGemSpecFileNoParens = `
+Gem::Specification.new do |spec|
+  spec.name        = 'mygem'
+  spec.version     = Mygem::VERSION
+  spec.platform    = Gem::Platform::RUBY
+  spec.add_development_dependency 'rake', '13.0.6'
 end
 `


### PR DESCRIPTION
Some gemspec files don’t use '(' when declaring dependencies.

e.g. `s.add_development_dependency "rake"`

Support with and without '(' in the gemspec file.