### PR TITLE
Add yarn-berry support

### DIFF
--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -210,6 +210,65 @@ workflows:
 `,
 		},
 		{
+			testName: "node codebase with yarn.lock and .yarnrc.yml file",
+			labels: labels.LabelSet{
+				labels.DepsNode: labels.Label{
+					Key:       labels.DepsNode,
+					Valid:     true,
+					LabelData: labels.LabelData{BasePath: ".", HasLockFile: true},
+				},
+				labels.TestJest: labels.Label{
+					Key:       labels.TestJest,
+					Valid:     true,
+					LabelData: labels.LabelData{BasePath: "."},
+				},
+				labels.PackageManagerYarn: labels.Label{
+					Key:       labels.PackageManagerYarn,
+					Valid:     true,
+					LabelData: labels.LabelData{BasePath: ".", Version: "berry"},
+				},
+			},
+			expected: `# This config was automatically generated from your source code
+# Stacks detected: deps:node:.,package_manager:yarn:.,test:jest:.
+version: 2.1
+orbs:
+  node: circleci/node@5
+jobs:
+  test-node:
+    # Install node dependencies and run tests
+    executor: node/default
+    environment:
+      JEST_JUNIT_OUTPUT_DIR: ./test-results/
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: yarn
+      - run:
+          command: yarn add jest-junit
+      - run:
+          name: Run tests with Jest
+          command: jest --ci --runInBand --reporters=default --reporters=jest-junit
+      - store_test_results:
+          path: ./test-results/
+  deploy:
+    # This is an example deploy job, not actually used by the workflow
+    docker:
+      - image: cimg/base:stable
+    steps:
+      # Replace this with steps to deploy to users
+      - run:
+          name: deploy
+          command: '#e.g. ./deploy.sh'
+workflows:
+  build-and-test:
+    jobs:
+      - test-node
+    # - deploy:
+    #     requires:
+    #       - test-node
+`,
+		},
+		{
 			testName: "node codebase without a lock file",
 			labels: labels.LabelSet{
 				labels.DepsNode: labels.Label{

--- a/generation/internal/node.go
+++ b/generation/internal/node.go
@@ -87,9 +87,15 @@ func nodeTestJob(ls labels.LabelSet) *Job {
 
 	if hasJestLabel && ls[labels.DepsNode].Dependencies["jest-junit"] == "" {
 		if packageManager == "yarn" {
+			command := "yarn add jest-junit --ignore-workspace-root-check"
+
+			if ls[labels.PackageManagerYarn].Version == "berry" {
+				// yarn-berry doesn't support --ignore-workspace-root-check and it's not needed in this case
+				command = "yarn add jest-junit"
+			}
 			steps = append(steps, config.Step{
 				Type:    config.Run,
-				Command: "yarn add jest-junit --ignore-workspace-root-check",
+				Command: command,
 			})
 		} else {
 			steps = append(steps, config.Step{

--- a/labeling/internal/node.go
+++ b/labeling/internal/node.go
@@ -32,7 +32,19 @@ var NodeRules = []labels.Rule{
 	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {
 		label.Key = labels.PackageManagerYarn
 		yarnLock, _ := c.FindFile("yarn.lock")
-		label.Valid = yarnLock != ""
+
+		if yarnLock == "" {
+			return label, err
+		}
+
+		label.Valid = true
+		label.Version = "classic"
+
+		yarnrc, _ := c.FindFile(".yarnrc.yml", ".yarnrc.yaml")
+		if yarnrc != "" {
+			label.Version = "berry"
+		}
+
 		return label, err
 	},
 	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {

--- a/labeling/labeling_test.go
+++ b/labeling/labeling_test.go
@@ -194,6 +194,9 @@ func TestCodebase_ApplyRules_Node(t *testing.T) {
 					},
 				}, {
 					Key: labels.PackageManagerYarn,
+					LabelData: labels.LabelData{
+						Version: "classic",
+					},
 				},
 				{
 					Key: labels.TestJest,
@@ -214,6 +217,32 @@ func TestCodebase_ApplyRules_Node(t *testing.T) {
 							"mylib": ">3.0",
 						},
 						HasLockFile: false,
+					},
+				},
+			},
+		},
+		{
+			name: "deps:node and package_manager:yarn with version berry",
+			files: map[string]string{
+				"package.json": `{"dependencies": {"mylib": ">3.0"}}`,
+				"yarn.lock":    "yarn.lock file",
+				".yarnrc.yml":  "yarnrc file",
+			},
+			expectedLabels: []labels.Label{
+				{
+					Key: labels.DepsNode,
+					LabelData: labels.LabelData{
+						BasePath: ".",
+						Dependencies: map[string]string{
+							"mylib": ">3.0",
+						},
+						HasLockFile: true,
+					},
+				},
+				{
+					Key: labels.PackageManagerYarn,
+					LabelData: labels.LabelData{
+						Version: "berry",
 					},
 				},
 			},

--- a/labeling/labels/labels.go
+++ b/labeling/labels/labels.go
@@ -29,6 +29,7 @@ type LabelData struct {
 	Dependencies map[string]string
 	Tasks        map[string]string
 	HasLockFile  bool
+	Version      string
 }
 
 // Label is the result of applying a Rule


### PR DESCRIPTION
Adding support for yarn berry. Noticed some projects were using Yarn Berry (aka Yarn 2) where the jest-junit install would fail because yarn-berry doesn't support `--ignore-workspace-root-check`.

Added a `Version` field to the label data to add the yarn version.
