### PR TITLE
 Better handling for node repos that don't test

### DIFF
--- a/cmd/inferconfig/testdata/expected/circleci-demo-javascript-express.yml
+++ b/cmd/inferconfig/testdata/expected/circleci-demo-javascript-express.yml
@@ -13,7 +13,7 @@ jobs:
           pkg-manager: npm
       - run:
           name: Run tests
-          command: npm run test
+          command: npm test
   build-node:
     # Build node project
     executor: node/default

--- a/cmd/inferconfig/testdata/expected/circleci-demo-javascript-express.yml
+++ b/cmd/inferconfig/testdata/expected/circleci-demo-javascript-express.yml
@@ -14,6 +14,25 @@ jobs:
       - run:
           name: Run tests
           command: npm run test
+  build-node:
+    # Build node project
+    executor: node/default
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: npm
+      - run:
+          command: npm run build
+      - run:
+          name: Create the ~/artifacts directory if it doesn't exist
+          command: mkdir -p ~/artifacts
+      # Copy output to artifacts dir
+      - run:
+          name: Copy artifacts
+          command: cp -R build dist public .output .next .docusaurus ~/artifacts 2>/dev/null || true
+      - store_artifacts:
+          path: ~/artifacts
+          destination: node-build
   deploy:
     # This is an example deploy job, not actually used by the workflow
     docker:
@@ -27,6 +46,9 @@ workflows:
   build-and-test:
     jobs:
       - test-node
+      - build-node:
+          requires:
+            - test-node
     # - deploy:
     #     requires:
-    #       - test-node
+    #       - build-node

--- a/cmd/inferconfig/testdata/expected/circleci-demo-ruby-rails.yml
+++ b/cmd/inferconfig/testdata/expected/circleci-demo-ruby-rails.yml
@@ -2,19 +2,8 @@
 # Stacks detected: deps:node:.,deps:ruby:.,package_manager:yarn:
 version: 2.1
 orbs:
-  node: circleci/node@5
   ruby: circleci/ruby@2.0.1
 jobs:
-  test-node:
-    # Install node dependencies and run tests
-    executor: node/default
-    steps:
-      - checkout
-      - node/install-packages:
-          pkg-manager: yarn
-      - run:
-          name: Run tests
-          command: yarn test
   test-ruby:
     # Install gems, run rspec tests
     docker:
@@ -44,9 +33,7 @@ jobs:
 workflows:
   build-and-test:
     jobs:
-      - test-node
       - test-ruby
     # - deploy:
     #     requires:
-    #       - test-node
     #       - test-ruby

--- a/cmd/inferconfig/testdata/expected/dogfood.yml
+++ b/cmd/inferconfig/testdata/expected/dogfood.yml
@@ -64,5 +64,4 @@ workflows:
             - test-go
     # - deploy:
     #     requires:
-    #       - test-go
     #       - build-go-executables

--- a/cmd/inferconfig/testdata/expected/dogfood.yml
+++ b/cmd/inferconfig/testdata/expected/dogfood.yml
@@ -45,6 +45,7 @@ jobs:
           command: go build -o ~/artifacts ./...
       - store_artifacts:
           path: ~/artifacts
+          destination: executables
   deploy:
     # This is an example deploy job, not actually used by the workflow
     docker:

--- a/config/config.go
+++ b/config/config.go
@@ -191,13 +191,14 @@ type OrbCommandParameters map[string]string
 // Step definitions for Jobs. Go has no sum types, so for now just throw all supported fields under
 // one struct
 type Step struct {
-	Type       StepType
-	Comment    string
-	Name       string // only used for run step
-	Command    string // for run steps or orb-defined commands
-	CacheKey   string
-	Path       string               // cache, artifact or test results path
-	Parameters OrbCommandParameters // for orb-defined steps
+	Type        StepType
+	Comment     string
+	Name        string // only used for run step
+	Command     string // for run steps or orb-defined commands
+	CacheKey    string
+	Path        string               // cache, artifact or test results path
+	Destination string               // artifact destination
+	Parameters  OrbCommandParameters // for orb-defined steps
 }
 
 func (s Step) YamlNode() *yaml.Node {
@@ -237,10 +238,11 @@ func (s Step) YamlNode() *yaml.Node {
 				yScalar("key"), yScalar(s.CacheKey)))
 
 	case StoreArtifacts:
-		return yCommentedMap(s.Comment,
-			yScalar("store_artifacts"),
-			yMap(
-				yScalar("path"), yScalar(s.Path)))
+		kvs := []*yaml.Node{yScalar("path"), yScalar(s.Path)}
+		if s.Destination != "" {
+			kvs = append(kvs, yScalar("destination"), yScalar(s.Destination))
+		}
+		return yCommentedMap(s.Comment, yScalar("store_artifacts"), yMap(kvs...))
 
 	case StoreTestResults:
 		return yCommentedMap(s.Comment,

--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -368,6 +368,71 @@ workflows:
 `,
 		},
 		{
+			testName: "node codebase with build task",
+			labels: labels.LabelSet{
+				labels.DepsNode: labels.Label{
+					Key:       labels.DepsNode,
+					Valid:     true,
+					LabelData: labels.LabelData{BasePath: ".", HasLockFile: true, Tasks: map[string]string{"build": "echo hi"}},
+				},
+			},
+			expected: `# This config was automatically generated from your source code
+# Stacks detected: deps:node:.
+version: 2.1
+orbs:
+  node: circleci/node@5
+jobs:
+  test-node:
+    # Install node dependencies and run tests
+    executor: node/default
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: npm
+      - run:
+          name: Run tests
+          command: npm test
+  build-node:
+    # Build node project
+    executor: node/default
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: npm
+      - run:
+          command: npm run build
+      - run:
+          name: Create the ~/artifacts directory if it doesn't exist
+          command: mkdir -p ~/artifacts
+      # Copy output to artifacts dir
+      - run:
+          name: Copy artifacts
+          command: cp -R build dist public .output .next .docusaurus ~/artifacts 2>/dev/null || true
+      - store_artifacts:
+          path: ~/artifacts
+          destination: node-build
+  deploy:
+    # This is an example deploy job, not actually used by the workflow
+    docker:
+      - image: cimg/base:stable
+    steps:
+      # Replace this with steps to deploy to users
+      - run:
+          name: deploy
+          command: '#e.g. ./deploy.sh'
+workflows:
+  build-and-test:
+    jobs:
+      - test-node
+      - build-node:
+          requires:
+            - test-node
+    # - deploy:
+    #     requires:
+    #       - build-node
+`,
+		},
+		{
 			testName: "python codebase with poetry package manager",
 			labels: labels.LabelSet{
 				labels.DepsPython: labels.Label{

--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -288,7 +288,6 @@ jobs:
     executor: node/default
     steps:
       - checkout
-      # Update the default install command as the project doesn't have a lock file
       - node/install-packages:
           cache-path: ~/project/node_modules
           override-ci-command: npm install

--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -94,7 +94,7 @@ workflows:
 				labels.DepsNode: labels.Label{
 					Key:       labels.DepsNode,
 					Valid:     true,
-					LabelData: labels.LabelData{BasePath: "node-dir", HasLockFile: true},
+					LabelData: labels.LabelData{BasePath: "node-dir", HasLockFile: true, Tasks: map[string]string{"test": "false"}},
 				},
 				labels.DepsGo: labels.Label{
 					Key:       labels.DepsGo,
@@ -167,7 +167,7 @@ workflows:
 				labels.DepsNode: labels.Label{
 					Key:       labels.DepsNode,
 					Valid:     true,
-					LabelData: labels.LabelData{BasePath: ".", HasLockFile: true},
+					LabelData: labels.LabelData{BasePath: ".", HasLockFile: true, Tasks: map[string]string{"test": "false"}},
 				},
 				labels.PackageManagerYarn: labels.Label{
 					Key:       labels.PackageManagerYarn,
@@ -274,7 +274,7 @@ workflows:
 				labels.DepsNode: labels.Label{
 					Key:       labels.DepsNode,
 					Valid:     true,
-					LabelData: labels.LabelData{BasePath: ".", HasLockFile: false},
+					LabelData: labels.LabelData{BasePath: ".", HasLockFile: false, Tasks: map[string]string{"test": "false"}},
 				},
 			},
 			expected: `# This config was automatically generated from your source code
@@ -382,16 +382,6 @@ version: 2.1
 orbs:
   node: circleci/node@5
 jobs:
-  test-node:
-    # Install node dependencies and run tests
-    executor: node/default
-    steps:
-      - checkout
-      - node/install-packages:
-          pkg-manager: npm
-      - run:
-          name: Run tests
-          command: npm test
   build-node:
     # Build node project
     executor: node/default
@@ -421,12 +411,9 @@ jobs:
           name: deploy
           command: '#e.g. ./deploy.sh'
 workflows:
-  build-and-test:
+  build:
     jobs:
-      - test-node
-      - build-node:
-          requires:
-            - test-node
+      - build-node
     # - deploy:
     #     requires:
     #       - build-node

--- a/generation/internal/common.go
+++ b/generation/internal/common.go
@@ -34,7 +34,10 @@ var createArtifactsDirStep = config.Step{
 	Command: fmt.Sprintf("mkdir -p %s", artifactsPath),
 }
 
-var storeArtifactsStep = config.Step{
-	Type: config.StoreArtifacts,
-	Path: artifactsPath,
+func storeArtifactsStep(destination string) config.Step {
+	return config.Step{
+		Type:        config.StoreArtifacts,
+		Path:        artifactsPath,
+		Destination: destination,
+	}
 }

--- a/generation/internal/go.go
+++ b/generation/internal/go.go
@@ -60,7 +60,7 @@ func goBuildJob(ls labels.LabelSet) *Job {
 			Name:    "Build executables",
 			Command: fmt.Sprintf("go build -o %s ./...", artifactsPath),
 		},
-		storeArtifactsStep)
+		storeArtifactsStep("executables"))
 
 	return &Job{
 		Job: config.Job{

--- a/generation/internal/jobs.go
+++ b/generation/internal/jobs.go
@@ -56,7 +56,7 @@ func addStubJobs(jobs []*Job) []*Job {
 		jobTypesPresent[j.Type] = true
 	}
 
-	if !jobTypesPresent[TestJob] {
+	if !jobTypesPresent[TestJob] && !jobTypesPresent[ArtifactJob] {
 		jobs = append(jobs, &stubTestJob)
 	}
 	if !jobTypesPresent[DeployJob] {
@@ -98,8 +98,16 @@ func buildWorkflows(jobs []*Job) []*config.Workflow {
 		workflowJobs[i].Requires = workflowJobRequires(j, jobs)
 	}
 
+	name := "build"
+
+	for _, j := range jobs {
+		if j.Type == TestJob {
+			name = "build-and-test"
+		}
+	}
+
 	return []*config.Workflow{{
-		Name: "build-and-test",
+		Name: name,
 		Jobs: workflowJobs,
 	}}
 }

--- a/generation/internal/jobs.go
+++ b/generation/internal/jobs.go
@@ -112,11 +112,12 @@ func workflowJobRequires(job *Job, allJobs []*Job) []*config.Job {
 	}
 
 	if job.Type == DeployJob {
-		requires := []*config.Job{}
-		requires = append(requires, jobsByType[TestJob]...)
-		requires = append(requires, jobsByType[ArtifactJob]...)
-
-		return requires
+		// if there are artifact jobs, it's sufficient to depend on them,
+		// as they already depend on any test jobs themselves
+		if len(jobsByType[ArtifactJob]) > 0 {
+			return jobsByType[ArtifactJob]
+		}
+		return jobsByType[TestJob]
 	}
 
 	return []*config.Job{}

--- a/generation/internal/node.go
+++ b/generation/internal/node.go
@@ -13,6 +13,43 @@ func npmTaskDefined(ls labels.LabelSet, task string) bool {
 	return ls[labels.DepsNode].Tasks[task] != ""
 }
 
+func nodePackageManager(ls labels.LabelSet) string {
+	if ls[labels.PackageManagerYarn].Valid {
+		return "yarn"
+	}
+	return "npm"
+}
+
+func nodeRunCommand(ls labels.LabelSet, task string) string {
+	return fmt.Sprintf("%s run %s", nodePackageManager(ls), task)
+}
+
+func nodeInitialSteps(ls labels.LabelSet) []config.Step {
+	steps := []config.Step{
+		checkoutStep(ls[labels.DepsNode]),
+	}
+
+	if ls[labels.DepsNode].HasLockFile {
+		steps = append(steps, config.Step{
+			Type:    config.OrbCommand,
+			Command: "node/install-packages",
+			Parameters: config.OrbCommandParameters{
+				"pkg-manager": nodePackageManager(ls),
+			}})
+	} else {
+		steps = append(steps, config.Step{
+			Comment: "Update the default install command as the project doesn't have a lock file",
+			Type:    config.OrbCommand,
+			Command: "node/install-packages",
+			Parameters: config.OrbCommandParameters{
+				"cache-path":          "~/project/node_modules",
+				"override-ci-command": fmt.Sprintf("%s install", nodePackageManager(ls)),
+			}})
+	}
+
+	return steps
+}
+
 func nodeTestSteps(ls labels.LabelSet, packageManager string) []config.Step {
 	hasJestLabel := ls[labels.TestJest].Valid
 
@@ -63,27 +100,7 @@ func nodeTestJob(ls labels.LabelSet) *Job {
 		packageManager = "yarn"
 	}
 
-	steps := []config.Step{
-		checkoutStep(ls[labels.DepsNode]),
-	}
-
-	if ls[labels.DepsNode].HasLockFile {
-		steps = append(steps, config.Step{
-			Type:    config.OrbCommand,
-			Command: "node/install-packages",
-			Parameters: config.OrbCommandParameters{
-				"pkg-manager": packageManager,
-			}})
-	} else {
-		steps = append(steps, config.Step{
-			Comment: "Update the default install command as the project doesn't have a lock file",
-			Type:    config.OrbCommand,
-			Command: "node/install-packages",
-			Parameters: config.OrbCommandParameters{
-				"cache-path":          "~/project/node_modules",
-				"override-ci-command": fmt.Sprintf("%s install", packageManager),
-			}})
-	}
+	steps := nodeInitialSteps(ls)
 
 	if hasJestLabel && ls[labels.DepsNode].Dependencies["jest-junit"] == "" {
 		if packageManager == "yarn" {
@@ -136,10 +153,67 @@ func nodeTestJob(ls labels.LabelSet) *Job {
 	}
 }
 
-func GenerateNodeJobs(ls labels.LabelSet) []*Job {
+func nodeBuildJob(ls labels.LabelSet) *Job {
+	// Possible build task names in order of preference
+	buildTasks := []string{
+		"build:ci",
+		"build:production",
+		"build:prod",
+		"build",
+		"build:development",
+		"build:dev",
+	}
+
+	steps := nodeInitialSteps(ls)
+
+	for _, task := range buildTasks {
+		if npmTaskDefined(ls, task) {
+
+			steps = append(steps, []config.Step{
+				{
+					Type:    config.Run,
+					Command: nodeRunCommand(ls, task),
+				},
+				createArtifactsDirStep,
+				{
+					Type:    config.Run,
+					Comment: "Copy output to artifacts dir",
+					Name:    "Copy artifacts",
+					Command: "cp -R build dist public .output .next .docusaurus ~/artifacts 2>/dev/null || true",
+				},
+				storeArtifactsStep("node-build")}...)
+
+			return &Job{
+				Job: config.Job{
+					Name:             "build-node",
+					Comment:          "Build node project",
+					Executor:         "node/default",
+					WorkingDirectory: workingDirectory(ls[labels.DepsNode]),
+					Steps:            steps,
+				},
+				Type: ArtifactJob,
+				Orbs: map[string]string{"node": nodeOrb},
+			}
+		}
+	}
+
+	return nil
+}
+
+func GenerateNodeJobs(ls labels.LabelSet) (jobs []*Job) {
 	if !ls[labels.DepsNode].Valid {
 		return nil
 	}
 
-	return []*Job{nodeTestJob(ls)}
+	testJob := nodeTestJob(ls)
+	if testJob != nil {
+		jobs = append(jobs, testJob)
+	}
+
+	buildJob := nodeBuildJob(ls)
+	if buildJob != nil {
+		jobs = append(jobs, buildJob)
+	}
+
+	return jobs
 }

--- a/generation/internal/node.go
+++ b/generation/internal/node.go
@@ -32,23 +32,20 @@ func nodeInitialSteps(ls labels.LabelSet) []config.Step {
 		checkoutStep(ls[labels.DepsNode]),
 	}
 
-	if ls[labels.DepsNode].HasLockFile {
-		steps = append(steps, config.Step{
-			Type:    config.OrbCommand,
-			Command: "node/install-packages",
-			Parameters: config.OrbCommandParameters{
-				"pkg-manager": nodePackageManager(ls),
-			}})
-	} else {
-		steps = append(steps, config.Step{
-			Comment: "Update the default install command as the project doesn't have a lock file",
-			Type:    config.OrbCommand,
-			Command: "node/install-packages",
-			Parameters: config.OrbCommandParameters{
-				"cache-path":          "~/project/node_modules",
-				"override-ci-command": fmt.Sprintf("%s install", nodePackageManager(ls)),
-			}})
+	installParams := config.OrbCommandParameters{
+		"pkg-manager": nodePackageManager(ls),
 	}
+	if !ls[labels.DepsNode].HasLockFile {
+		installParams = config.OrbCommandParameters{
+			"cache-path":          "~/project/node_modules",
+			"override-ci-command": fmt.Sprintf("%s install", nodePackageManager(ls)),
+		}
+	}
+
+	steps = append(steps, config.Step{
+		Type:       config.OrbCommand,
+		Command:    "node/install-packages",
+		Parameters: installParams})
 
 	return steps
 }


### PR DESCRIPTION
These are repos that typically generate some static artifact, like static site builders.

This adds node build jobs that run `npm/yarn build` (or similar tasks) and store the artifacts.

For repos that have a build job, stop requiring a test job.