### PR TITLE
Run rails tests for rails projects missing rake or rspec in Gemfile

### DIFF
--- a/generation/internal/ruby.go
+++ b/generation/internal/ruby.go
@@ -14,6 +14,8 @@ func GenerateRubyJobs(ls labels.LabelSet) (jobs []*Job) {
 		jobs = append(jobs, rakeJob(ls))
 	} else if hasGem(ls, "rspec") {
 		jobs = append(jobs, rspecJob(ls))
+	} else if hasGem(ls, "rails") {
+		jobs = append(jobs, railsTestJob(ls))
 	}
 	return jobs
 }
@@ -104,6 +106,30 @@ func rakeJob(ls labels.LabelSet) *Job {
 		Job: config.Job{
 			Name:             "test-ruby",
 			Comment:          "Install gems, run rake tests",
+			Steps:            steps,
+			DockerImages:     []string{rubyImageVersion(ls)},
+			WorkingDirectory: workingDirectory(ls[labels.DepsRuby]),
+		},
+
+		Orbs: map[string]string{
+			"ruby": rubyOrb,
+		},
+	}
+}
+
+func railsTestJob(ls labels.LabelSet) *Job {
+	steps := rubyInitialSteps(ls)
+	steps = append(steps,
+		config.Step{
+			Type:    config.Run,
+			Name:    "rails test",
+			Command: "bundle exec rails test",
+		})
+
+	return &Job{
+		Job: config.Job{
+			Name:             "test-ruby",
+			Comment:          "Install gems, run rails tests",
 			Steps:            steps,
 			DockerImages:     []string{rubyImageVersion(ls)},
 			WorkingDirectory: workingDirectory(ls[labels.DepsRuby]),

--- a/generation/internal/ruby_test.go
+++ b/generation/internal/ruby_test.go
@@ -156,6 +156,43 @@ func TestGenerateRubyJobs(t *testing.T) {
 			},
 		},
 		{
+			name: "gemfile has rails w/o rake or rspec",
+			args: args{ls: labels.LabelSet{
+				labels.DepsRuby: labels.Label{
+					Valid: true,
+					LabelData: labels.LabelData{
+						Dependencies: map[string]string{"rails": "true"},
+						HasLockFile:  true,
+					},
+				}}},
+			wantJobs: []*Job{
+				{
+					Job: config.Job{
+						Name:             "test-ruby",
+						Comment:          "Install gems, run rails tests",
+						DockerImages:     []string{"cimg/ruby:3.2-node"},
+						WorkingDirectory: "~/project",
+						Steps: []config.Step{
+							{
+								Path: "~/project",
+								Type: config.Checkout,
+							},
+							{
+								Command: "ruby/install-deps",
+								Type:    config.OrbCommand,
+							},
+							{
+								Type:    config.Run,
+								Name:    "rails test",
+								Command: "bundle exec rails test",
+							},
+						}},
+					Type: TestJob,
+					Orbs: map[string]string{"ruby": "circleci/ruby@2.0.1"},
+				},
+			},
+		},
+		{
 			name: "gemfile has rspec",
 			args: args{ls: labels.LabelSet{
 				labels.DepsRuby: labels.Label{

--- a/labeling/internal/ruby.go
+++ b/labeling/internal/ruby.go
@@ -68,6 +68,7 @@ func readDepsFile(c codebase.Codebase, deps map[string]string, filePath string) 
 		}
 
 		gems := map[string]string{
+			"rails":                 "rails",
 			"rspec-rails":           "rspec",
 			"rspec":                 "rspec",
 			"rspec_junit_formatter": "rspec_junit_formatter",

--- a/labeling/ruby_test.go
+++ b/labeling/ruby_test.go
@@ -28,6 +28,7 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 					LabelData: labels.LabelData{
 						BasePath: ".",
 						Dependencies: map[string]string{
+							"rails":                 "true",
 							"ruby":                  "2.7.8",
 							"rspec":                 "true",
 							"rspec_junit_formatter": "true",
@@ -69,6 +70,7 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 					LabelData: labels.LabelData{
 						BasePath: ".",
 						Dependencies: map[string]string{
+							"rails": "true",
 							"ruby":  "2.7.8",
 							"rspec": "true",
 							"pg":    "true",
@@ -89,7 +91,8 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 					LabelData: labels.LabelData{
 						BasePath: ".",
 						Dependencies: map[string]string{
-							"ruby": "1.9.3",
+							"rails": "true",
+							"ruby":  "1.9.3",
 						},
 					},
 				},
@@ -143,6 +146,7 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 					LabelData: labels.LabelData{
 						BasePath: ".",
 						Dependencies: map[string]string{
+							"rails":                 "true",
 							"ruby":                  "2.7.8",
 							"rspec":                 "true",
 							"rspec_junit_formatter": "true",
@@ -157,6 +161,23 @@ func TestCodebase_ApplyRubyRules(t *testing.T) {
 							"rake":                  "true",
 							"rspec":                 "true",
 							"rspec_junit_formatter": "true",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Ruby Gemfile with rails, but without rake or rspec",
+			files: map[string]string{
+				"Gemfile": "gem 'rails', '~> 7.0.5'",
+			},
+			expectedLabels: []labels.Label{
+				{
+					Key: labels.DepsRuby,
+					LabelData: labels.LabelData{
+						BasePath: ".",
+						Dependencies: map[string]string{
+							"rails": "true",
 						},
 					},
 				},


### PR DESCRIPTION
If a rails project is not using rake or rspec, we should create a ruby test job that uses the `rails test` command.