### PR TITLE
Update rust docker image to 1.70

### DIFF
--- a/cmd/inferconfig/testdata/expected/rust-orb.yml
+++ b/cmd/inferconfig/testdata/expected/rust-orb.yml
@@ -6,7 +6,8 @@ orbs:
 jobs:
   test-rust:
     # Run tests using the rust orb
-    executor: rust/default
+    docker:
+      - image: cimg/rust:1.70
     working_directory: ~/project/sample
     steps:
       - checkout:

--- a/generation/internal/rust.go
+++ b/generation/internal/rust.go
@@ -6,6 +6,7 @@ import (
 )
 
 const rustOrb = "circleci/rust@1.6.0"
+const rustDockerImage = "cimg/rust:1.70"
 
 func rustInitialSteps(ls labels.LabelSet) []config.Step {
 	return []config.Step{checkoutStep(ls[labels.DepsRust])}
@@ -23,7 +24,7 @@ func rustTestJob(ls labels.LabelSet) *Job {
 		Job: config.Job{
 			Name:             "test-rust",
 			Comment:          "Run tests using the rust orb",
-			Executor:         "rust/default",
+			DockerImages:     []string{rustDockerImage},
 			WorkingDirectory: workingDirectory(ls[labels.DepsRust]),
 			Steps:            steps,
 		},


### PR DESCRIPTION
The orb uses 1.49.
We still use the orb for the rust/test orb command.