### PR TITLE
Pass labelset as map instead of pointer to map

### DIFF
--- a/labeling/internal/go.go
+++ b/labeling/internal/go.go
@@ -1,24 +1,25 @@
 package internal
 
 import (
-	"github.com/CircleCI-Public/circleci-config/labeling/codebase"
-	"github.com/CircleCI-Public/circleci-config/labeling/labels"
 	"go/parser"
 	"go/token"
 	"path"
+
+	"github.com/CircleCI-Public/circleci-config/labeling/codebase"
+	"github.com/CircleCI-Public/circleci-config/labeling/labels"
 )
 
 var GoRules = []labels.Rule{
-	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {
+	func(c codebase.Codebase, ls labels.LabelSet) (label labels.Label, err error) {
 		label.Key = labels.DepsGo
 		goModPath, err := c.FindFile("go.mod")
 		label.Valid = goModPath != ""
 		label.BasePath = path.Dir(goModPath)
 		return label, err
 	},
-	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {
+	func(c codebase.Codebase, ls labels.LabelSet) (label labels.Label, err error) {
 		label.Key = labels.ArtifactGoExecutable
-		if !(*ls)[labels.DepsGo].Valid {
+		if !ls[labels.DepsGo].Valid {
 			return label, err
 		}
 

--- a/labeling/internal/java.go
+++ b/labeling/internal/java.go
@@ -1,23 +1,24 @@
 package internal
 
 import (
+	"path"
+
 	"github.com/CircleCI-Public/circleci-config/labeling/codebase"
 	"github.com/CircleCI-Public/circleci-config/labeling/labels"
-	"path"
 )
 
 var JavaRules = []labels.Rule{
-	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {
+	func(c codebase.Codebase, ls labels.LabelSet) (label labels.Label, err error) {
 		label.Key = labels.DepsJava
 		pomXml, err := c.FindFile("pom.xml", "gradlew")
 		label.Valid = pomXml != ""
 		label.BasePath = path.Dir(pomXml)
 		return label, err
 	},
-	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {
+	func(c codebase.Codebase, ls labels.LabelSet) (label labels.Label, err error) {
 		label.Key = labels.ToolGradle
 		gradlew, err := c.FindFile("gradlew")
-		label.Valid = gradlew != "" && path.Dir(gradlew) == (*ls)[labels.DepsJava].BasePath
+		label.Valid = gradlew != "" && path.Dir(gradlew) == ls[labels.DepsJava].BasePath
 		return label, err
 	},
 }

--- a/labeling/internal/node.go
+++ b/labeling/internal/node.go
@@ -14,7 +14,7 @@ var lockFiles = []string{
 }
 
 var NodeRules = []labels.Rule{
-	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {
+	func(c codebase.Codebase, ls labels.LabelSet) (label labels.Label, err error) {
 		label.Key = labels.DepsNode
 		packagePath := findPackageJSON(c)
 		label.Valid = packagePath != ""
@@ -29,7 +29,7 @@ var NodeRules = []labels.Rule{
 
 		return label, err
 	},
-	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {
+	func(c codebase.Codebase, ls labels.LabelSet) (label labels.Label, err error) {
 		label.Key = labels.PackageManagerYarn
 		yarnLock, _ := c.FindFile("yarn.lock")
 
@@ -47,7 +47,7 @@ var NodeRules = []labels.Rule{
 
 		return label, err
 	},
-	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {
+	func(c codebase.Codebase, ls labels.LabelSet) (label labels.Label, err error) {
 		label.Key = labels.TestJest
 		label.Valid = hasDependency(ls, "jest")
 		return label, err
@@ -93,6 +93,6 @@ func readPackageJSON(c codebase.Codebase, filePath string, label *labels.Label) 
 	return err
 }
 
-func hasDependency(ls *labels.LabelSet, dep string) bool {
-	return (*ls)[labels.DepsNode].Dependencies[dep] != ""
+func hasDependency(ls labels.LabelSet, dep string) bool {
+	return ls[labels.DepsNode].Dependencies[dep] != ""
 }

--- a/labeling/internal/python.go
+++ b/labeling/internal/python.go
@@ -33,7 +33,7 @@ var possiblePythonFiles = append(
 )
 
 var PythonRules = []labels.Rule{
-	func(c codebase.Codebase, ls *labels.LabelSet) (labels.Label, error) {
+	func(c codebase.Codebase, ls labels.LabelSet) (labels.Label, error) {
 		label := labels.Label{
 			Key: labels.DepsPython,
 		}
@@ -50,7 +50,7 @@ var PythonRules = []labels.Rule{
 
 		return label, nil
 	},
-	func(c codebase.Codebase, ls *labels.LabelSet) (labels.Label, error) {
+	func(c codebase.Codebase, ls labels.LabelSet) (labels.Label, error) {
 		label := labels.Label{
 			Key: labels.PackageManagerPipenv,
 		}
@@ -66,7 +66,7 @@ var PythonRules = []labels.Rule{
 
 		return label, nil
 	},
-	func(c codebase.Codebase, ls *labels.LabelSet) (labels.Label, error) {
+	func(c codebase.Codebase, ls labels.LabelSet) (labels.Label, error) {
 		label := labels.Label{
 			Key: labels.PackageManagerPoetry,
 		}
@@ -82,7 +82,7 @@ var PythonRules = []labels.Rule{
 
 		return label, nil
 	},
-	func(c codebase.Codebase, ls *labels.LabelSet) (labels.Label, error) {
+	func(c codebase.Codebase, ls labels.LabelSet) (labels.Label, error) {
 		label := labels.Label{
 			Key: labels.FileManagePy,
 		}

--- a/labeling/internal/ruby.go
+++ b/labeling/internal/ruby.go
@@ -10,7 +10,7 @@ import (
 )
 
 var RubyRules = []labels.Rule{
-	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {
+	func(c codebase.Codebase, ls labels.LabelSet) (label labels.Label, err error) {
 		label.Key = labels.DepsRuby
 		label.Dependencies = make(map[string]string)
 
@@ -29,7 +29,7 @@ var RubyRules = []labels.Rule{
 		}
 		return label, nil
 	},
-	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {
+	func(c codebase.Codebase, ls labels.LabelSet) (label labels.Label, err error) {
 		label.Key = labels.PackageManagerGemspec
 		label.Dependencies = make(map[string]string)
 

--- a/labeling/internal/rust.go
+++ b/labeling/internal/rust.go
@@ -1,13 +1,14 @@
 package internal
 
 import (
+	"path"
+
 	"github.com/CircleCI-Public/circleci-config/labeling/codebase"
 	"github.com/CircleCI-Public/circleci-config/labeling/labels"
-	"path"
 )
 
 var RustRules = []labels.Rule{
-	func(c codebase.Codebase, ls *labels.LabelSet) (label labels.Label, err error) {
+	func(c codebase.Codebase, ls labels.LabelSet) (label labels.Label, err error) {
 		label.Key = labels.DepsRust
 		cargoTomlFile, err := c.FindFile("Cargo.toml", "cargo.toml")
 		label.Valid = cargoTomlFile != ""

--- a/labeling/labeling.go
+++ b/labeling/labeling.go
@@ -13,7 +13,7 @@ import (
 func ApplyRules(c codebase.Codebase, rules []labels.Rule) labels.LabelSet {
 	ls := make(labels.LabelSet)
 	for _, r := range rules {
-		label, err := r(c, &ls)
+		label, err := r(c, ls)
 		if err != nil {
 			continue
 		}

--- a/labeling/labels/labels.go
+++ b/labeling/labels/labels.go
@@ -62,4 +62,4 @@ func (ls LabelSet) String() string {
 	return strings.Join(labelsAsStrings, ",")
 }
 
-type Rule func(codebase.Codebase, *LabelSet) (Label, error)
+type Rule func(codebase.Codebase, LabelSet) (Label, error)


### PR DESCRIPTION
We don't need to pass the labelset as pointers as maps are already
pointers.

This removes the unnecessary dereferencing when we access the labelset
in rule functions.