### PR TITLE
Fix bug when generating cache key for java projects

### DIFF
--- a/cmd/inferconfig/testdata/expected/circleci-demo-java-spring.yml
+++ b/cmd/inferconfig/testdata/expected/circleci-demo-java-spring.yml
@@ -10,7 +10,7 @@ jobs:
       - run:
           name: Calculate cache key
           command: |-
-            find . -o -name 'pom.xml' -o -name 'gradlew*' -o -name '*.gradle*' | \
+            find . -name 'pom.xml' -o -name 'gradlew*' -o -name '*.gradle*' | \
                     sort | xargs cat > /tmp/CIRCLECI_CACHE_KEY
       - restore_cache:
           key: cache-{{ checksum "/tmp/CIRCLECI_CACHE_KEY" }}

--- a/cmd/inferconfig/testdata/expected/circleci-demo-react-native.yml
+++ b/cmd/inferconfig/testdata/expected/circleci-demo-react-native.yml
@@ -28,7 +28,7 @@ jobs:
       - run:
           name: Calculate cache key
           command: |-
-            find . -o -name 'pom.xml' -o -name 'gradlew*' -o -name '*.gradle*' | \
+            find . -name 'pom.xml' -o -name 'gradlew*' -o -name '*.gradle*' | \
                     sort | xargs cat > /tmp/CIRCLECI_CACHE_KEY
       - restore_cache:
           key: cache-{{ checksum "/tmp/CIRCLECI_CACHE_KEY" }}

--- a/cmd/inferconfig/testdata/expected/maven-orb.yml
+++ b/cmd/inferconfig/testdata/expected/maven-orb.yml
@@ -12,7 +12,7 @@ jobs:
       - run:
           name: Calculate cache key
           command: |-
-            find . -o -name 'pom.xml' -o -name 'gradlew*' -o -name '*.gradle*' | \
+            find . -name 'pom.xml' -o -name 'gradlew*' -o -name '*.gradle*' | \
                     sort | xargs cat > /tmp/CIRCLECI_CACHE_KEY
       - restore_cache:
           key: cache-{{ checksum "/tmp/CIRCLECI_CACHE_KEY" }}

--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -765,7 +765,7 @@ jobs:
       - run:
           name: Calculate cache key
           command: |-
-            find . -o -name 'pom.xml' -o -name 'gradlew*' -o -name '*.gradle*' | \
+            find . -name 'pom.xml' -o -name 'gradlew*' -o -name '*.gradle*' | \
                     sort | xargs cat > /tmp/CIRCLECI_CACHE_KEY
       - restore_cache:
           key: cache-{{ checksum "/tmp/CIRCLECI_CACHE_KEY" }}
@@ -822,7 +822,7 @@ jobs:
       - run:
           name: Calculate cache key
           command: |-
-            find . -o -name 'pom.xml' -o -name 'gradlew*' -o -name '*.gradle*' | \
+            find . -name 'pom.xml' -o -name 'gradlew*' -o -name '*.gradle*' | \
                     sort | xargs cat > /tmp/CIRCLECI_CACHE_KEY
       - restore_cache:
           key: cache-{{ checksum "/tmp/CIRCLECI_CACHE_KEY" }}

--- a/generation/internal/java.go
+++ b/generation/internal/java.go
@@ -25,7 +25,7 @@ func javaTestJob(ls labels.LabelSet) *Job {
 		testResultsPath = "target/surefire-reports"
 	}
 
-	cacheKeyCalcCommand := `find . -o -name 'pom.xml' -o -name 'gradlew*' -o -name '*.gradle*' | \
+	cacheKeyCalcCommand := `find . -name 'pom.xml' -o -name 'gradlew*' -o -name '*.gradle*' | \
         sort | xargs cat > /tmp/CIRCLECI_CACHE_KEY`
 	cacheKey := `cache-{{ checksum "/tmp/CIRCLECI_CACHE_KEY" }}`
 


### PR DESCRIPTION
I get
> find: invalid expression; you have used a binary operator '-o' with nothing before it.