### PR TITLE
Fix rust working dir & stop using rust orb

### DIFF
--- a/cmd/inferconfig/testdata/expected/rust-orb.yml
+++ b/cmd/inferconfig/testdata/expected/rust-orb.yml
@@ -1,18 +1,22 @@
 # This config was automatically generated from your source code
 # Stacks detected: deps:rust:sample
 version: 2.1
-orbs:
-  rust: circleci/rust@1.6.0
 jobs:
   test-rust:
-    # Run tests using the rust orb
     docker:
       - image: cimg/rust:1.70
     working_directory: ~/project/sample
     steps:
       - checkout:
           path: ~/project
-      - rust/test
+      - restore_cache:
+          key: cargo-{{ checksum "Cargo.lock" }}
+      - run:
+          command: cargo test
+      - save_cache:
+          key: cargo-{{ checksum "Cargo.lock" }}
+          paths:
+            - ~/.cargo
   deploy:
     # This is an example deploy job, not actually used by the workflow
     docker:


### PR DESCRIPTION
The "rust/test" orb command doesn't respect the job's working directory, so we would have had to pass a working_directory parameter. We are already not using the rust orb for anything else, so at this point I feel it's easier to just do caching and `cargo test` explicitly. For simpler cases/stacks I feel like _not_ using orbs also makes the generated config more obvious to the end user.