### PR TITLE
Add basic PHP support

### DIFF
--- a/cmd/inferconfig/inferconfig_test.go
+++ b/cmd/inferconfig/inferconfig_test.go
@@ -3,11 +3,12 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/go-git/go-git/v5/plumbing"
 	"net/url"
 	"os"
 	"path"
 	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -31,6 +32,7 @@ func TestInferConfig(t *testing.T) {
 		// There is no "demo" for rust or maven, but the orbs repo contain sample dirs
 		{url: "https://github.com/CircleCI-Public/rust-orb"},
 		{url: "https://github.com/CircleCI-Public/maven-orb", branch: "main"},
+		{url: "https://github.com/CircleCI-Public/sample-php-laravel", branch: "circleci-2.0"},
 	}
 
 	for _, tt := range tests {

--- a/cmd/inferconfig/testdata/expected/sample-php-laravel.yml
+++ b/cmd/inferconfig/testdata/expected/sample-php-laravel.yml
@@ -1,0 +1,32 @@
+# This config was automatically generated from your source code
+# Stacks detected: deps:node:.,deps:php:.
+version: 2.1
+orbs:
+  php: circleci/php@1.1.0
+jobs:
+  test-php:
+    # Install php packages and run tests
+    docker:
+      - image: cimg/php:8.2.7-node
+    steps:
+      - checkout
+      - php/install-packages
+      - run:
+          name: run tests
+          command: ./vendor/bin/phpunit
+  deploy:
+    # This is an example deploy job, not actually used by the workflow
+    docker:
+      - image: cimg/base:stable
+    steps:
+      # Replace this with steps to deploy to users
+      - run:
+          name: deploy
+          command: '#e.g. ./deploy.sh'
+workflows:
+  build-and-test:
+    jobs:
+      - test-php
+    # - deploy:
+    #     requires:
+    #       - test-php

--- a/cmd/inferconfig/testdata/expected/sample-php-laravel.yml
+++ b/cmd/inferconfig/testdata/expected/sample-php-laravel.yml
@@ -2,7 +2,7 @@
 # Stacks detected: deps:node:.,deps:php:.
 version: 2.1
 orbs:
-  php: circleci/php@1.1.0
+  php: circleci/php@1
 jobs:
   test-php:
     # Install php packages and run tests

--- a/generation/generation.go
+++ b/generation/generation.go
@@ -14,5 +14,6 @@ func GenerateConfig(labels labels.LabelSet) config.Config {
 	generatedJobs = append(generatedJobs, internal.GeneratePythonJobs(labels)...)
 	generatedJobs = append(generatedJobs, internal.GenerateRubyJobs(labels)...)
 	generatedJobs = append(generatedJobs, internal.GenerateRustJobs(labels)...)
+	generatedJobs = append(generatedJobs, internal.GeneratePHPJobs(labels)...)
 	return internal.BuildConfig(labels, generatedJobs)
 }

--- a/generation/internal/php.go
+++ b/generation/internal/php.go
@@ -1,0 +1,55 @@
+package internal
+
+import (
+	"github.com/CircleCI-Public/circleci-config/config"
+	"github.com/CircleCI-Public/circleci-config/labeling/labels"
+)
+
+func GeneratePHPJobs(ls labels.LabelSet) []*Job {
+	if !ls[labels.DepsPhp].Valid {
+		return nil
+	}
+
+	jobs := []*Job{}
+
+	if hasLib(ls, "phpunit/phpunit") {
+		jobs = append(jobs, phpunitJob(ls))
+	}
+	return jobs
+}
+
+func hasLib(ls labels.LabelSet, lib string) bool {
+	if ls[labels.DepsPhp].Dependencies[lib] != "" {
+		return true
+	}
+	return false
+}
+
+func initialPhpSteps(ls labels.LabelSet) []config.Step {
+	checkout := checkoutStep(ls[labels.DepsPhp])
+	installPackages := config.Step{
+		Type:    config.OrbCommand,
+		Command: "php/install-packages",
+	}
+	return []config.Step{checkout, installPackages}
+}
+
+func phpunitJob(ls labels.LabelSet) *Job {
+	steps := initialPhpSteps(ls)
+	steps = append(steps, config.Step{
+		Type:    config.Run,
+		Name:    "run tests",
+		Command: "./vendor/bin/phpunit",
+	})
+	return &Job{
+		Job: config.Job{
+			Name:         "test-php",
+			Comment:      "Install php packages and run tests",
+			Steps:        steps,
+			DockerImages: []string{"cimg/php:8.2.7-node"},
+		},
+		Orbs: map[string]string{
+			"php": "circleci/php@1.1.0",
+		},
+	}
+}

--- a/generation/internal/php.go
+++ b/generation/internal/php.go
@@ -12,13 +12,13 @@ func GeneratePHPJobs(ls labels.LabelSet) []*Job {
 
 	jobs := []*Job{}
 
-	if hasLib(ls, "phpunit/phpunit") {
-		jobs = append(jobs, phpunitJob(ls))
+	if hasPhpLib(ls, "phpunit/phpunit") {
+		jobs = append(jobs, phpTestJob(ls))
 	}
 	return jobs
 }
 
-func hasLib(ls labels.LabelSet, lib string) bool {
+func hasPhpLib(ls labels.LabelSet, lib string) bool {
 	if ls[labels.DepsPhp].Dependencies[lib] != "" {
 		return true
 	}
@@ -34,7 +34,7 @@ func initialPhpSteps(ls labels.LabelSet) []config.Step {
 	return []config.Step{checkout, installPackages}
 }
 
-func phpunitJob(ls labels.LabelSet) *Job {
+func phpTestJob(ls labels.LabelSet) *Job {
 	steps := initialPhpSteps(ls)
 	steps = append(steps, config.Step{
 		Type:    config.Run,
@@ -49,7 +49,7 @@ func phpunitJob(ls labels.LabelSet) *Job {
 			DockerImages: []string{"cimg/php:8.2.7-node"},
 		},
 		Orbs: map[string]string{
-			"php": "circleci/php@1.1.0",
+			"php": "circleci/php@1",
 		},
 	}
 }

--- a/generation/internal/php_test.go
+++ b/generation/internal/php_test.go
@@ -1,0 +1,69 @@
+package internal
+
+import (
+	"testing"
+
+	"github.com/CircleCI-Public/circleci-config/config"
+	"github.com/CircleCI-Public/circleci-config/labeling/labels"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGeneratePHPJobs(t *testing.T) {
+	type args struct {
+		ls labels.LabelSet
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantJobs []*Job
+	}{
+		{
+			name: "composer file has phpunit",
+			args: args{ls: labels.LabelSet{
+				labels.DepsPhp: labels.Label{
+					Valid: true,
+					LabelData: labels.LabelData{
+						Dependencies: map[string]string{"phpunit/phpunit": "~4.2"},
+						HasLockFile:  true,
+					},
+				}}},
+			wantJobs: []*Job{
+				{
+					Job: config.Job{
+						Name:             "test-php",
+						Comment:          "Install php packages and run tests",
+						WorkingDirectory: "",
+						DockerImages:     []string{"cimg/php:8.2.7-node"},
+						Steps: []config.Step{
+							{
+								Path: "~/project",
+								Type: config.Checkout,
+							},
+							{
+								Command: "php/install-packages",
+								Type:    config.OrbCommand,
+							},
+							{
+								Type:    config.Run,
+								Name:    "run tests",
+								Command: "./vendor/bin/phpunit",
+							},
+						}},
+					Type: TestJob,
+					Orbs: map[string]string{"php": "circleci/php@1.1.0"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotJobs := GeneratePHPJobs(tt.args.ls)
+			diff := cmp.Diff(tt.wantJobs, gotJobs)
+			if diff != "" {
+				t.Errorf("MakeGatewayInfo() mismatch (-want +got):\n%s", diff)
+			}
+
+		})
+	}
+}

--- a/generation/internal/php_test.go
+++ b/generation/internal/php_test.go
@@ -50,7 +50,7 @@ func TestGeneratePHPJobs(t *testing.T) {
 							},
 						}},
 					Type: TestJob,
-					Orbs: map[string]string{"php": "circleci/php@1.1.0"},
+					Orbs: map[string]string{"php": "circleci/php@1"},
 				},
 			},
 		},

--- a/labeling/internal/php.go
+++ b/labeling/internal/php.go
@@ -1,0 +1,55 @@
+package internal
+
+import (
+	"encoding/json"
+	"errors"
+	"path"
+
+	"github.com/CircleCI-Public/circleci-config/labeling/codebase"
+	"github.com/CircleCI-Public/circleci-config/labeling/labels"
+)
+
+var PhpRules = []labels.Rule{
+	func(c codebase.Codebase, ls labels.LabelSet) (label labels.Label, err error) {
+		label.Key = labels.DepsPhp
+		label.Dependencies = make(map[string]string)
+
+		composerPath, err := c.FindFile("composer.json")
+		if err != nil && !errors.Is(err, codebase.NotFoundError) {
+			return label, err
+
+		}
+		if composerPath != "" {
+			label.Valid = true
+			label.BasePath = path.Dir(composerPath)
+		}
+
+		err = readComposerFile(c, composerPath, &label)
+		return label, err
+	},
+}
+
+type composerJSON struct {
+	Dependencies    map[string]string `json:"require"`
+	DevDependencies map[string]string `json:"require-dev"`
+}
+
+func readComposerFile(c codebase.Codebase, filePath string, label *labels.Label) error {
+	fileContents, err := c.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+	var composerDeps composerJSON
+	err = json.Unmarshal(fileContents, &composerDeps)
+	if err != nil {
+		return err
+	}
+	label.Dependencies = make(map[string]string)
+	for k, v := range composerDeps.Dependencies {
+		label.Dependencies[k] = v
+	}
+	for k, v := range composerDeps.DevDependencies {
+		label.Dependencies[k] = v
+	}
+	return nil
+}

--- a/labeling/labeling.go
+++ b/labeling/labeling.go
@@ -34,6 +34,7 @@ func ApplyAllRules(c codebase.Codebase) labels.LabelSet {
 		internal.PythonRules,
 		internal.RubyRules,
 		internal.RustRules,
+		internal.PhpRules,
 		// Add other stacks here
 	}
 

--- a/labeling/labels/labels.go
+++ b/labeling/labels/labels.go
@@ -17,6 +17,7 @@ const (
 	DepsPython            = "deps:python"
 	DepsRuby              = "deps:ruby"
 	DepsRust              = "deps:rust"
+	DepsPhp               = "deps:php"
 	PackageManagerPipenv  = "package_manager:pipenv"
 	PackageManagerPoetry  = "package_manager:poetry"
 	PackageManagerYarn    = "package_manager:yarn"

--- a/labeling/php_test.go
+++ b/labeling/php_test.go
@@ -1,0 +1,70 @@
+package labeling
+
+import (
+	"testing"
+
+	"github.com/CircleCI-Public/circleci-config/labeling/labels"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCodebase_ApplyPhpRules(t *testing.T) {
+	tests := []struct {
+		name           string
+		files          map[string]string
+		expectedLabels []labels.Label
+	}{
+		{
+			name: "phpunit in composer file",
+			files: map[string]string{
+				"composer.json": composerWithPhpUnit,
+			},
+			expectedLabels: []labels.Label{
+				{
+					Key:   labels.DepsPhp,
+					Valid: true,
+					LabelData: labels.LabelData{
+						BasePath: ".",
+						Dependencies: map[string]string{
+							"laravel/framework":       "5.4.*",
+							"symfony/http-foundation": "3.4.35",
+							"phpunit/phpunit":         "~4.0",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := fakeCodebase{tt.files}
+			expected := make(labels.LabelSet)
+			for _, label := range tt.expectedLabels {
+				// all should be Valid
+				label.Valid = true
+				expected[label.Key] = label
+			}
+			got := ApplyAllRules(c)
+			if diff := cmp.Diff(expected, got); diff != "" {
+				t.Errorf("ApplyAllRules mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+const composerWithPhpUnit = `
+{
+  "name": "laravel/laravel",
+  "description": "The Laravel Framework.",
+  "keywords": ["framework", "laravel"],
+  "license": "MIT",
+  "type": "project",
+  "require": {
+    "laravel/framework": "5.4.*",
+    "symfony/http-foundation": "3.4.35"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "~4.0"
+  }
+}			
+`


### PR DESCRIPTION
This will infer a PHP project using composer for dependencies and phpunit for tests, which are the defaults for Laravel projects.

I expect the test job won't pass for most projects, as other dependencies like a database or redis are often required. This is the minimum to get tests running.
