### PR TITLE
Infer the php image from the composer.json when present

### DIFF
--- a/generation/internal/php.go
+++ b/generation/internal/php.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/CircleCI-Public/circleci-config/config"
@@ -39,9 +40,14 @@ func initialPhpSteps(ls labels.LabelSet) []config.Step {
 func phpImageVersion(composerVersion string) string {
 	version := "8.2.7"
 	if composerVersion != "" {
-		version = strings.TrimPrefix(composerVersion, "~")
-		version = strings.TrimPrefix(version, "^")
-		version = strings.TrimSuffix(version, ".*")
+		composerVersion = strings.TrimPrefix(composerVersion, "~")
+		composerVersion = strings.TrimPrefix(composerVersion, "^")
+		composerVersion = strings.TrimSuffix(composerVersion, ".*")
+		versionRegex := regexp.MustCompile(`^[0-9].[0-9]`)
+		versionMatch := versionRegex.FindString(composerVersion)
+		if versionMatch != "" {
+			version = versionMatch
+		}
 	}
 	return "cimg/php:" + version + "-node"
 }

--- a/generation/internal/php.go
+++ b/generation/internal/php.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"strings"
+
 	"github.com/CircleCI-Public/circleci-config/config"
 	"github.com/CircleCI-Public/circleci-config/labeling/labels"
 )
@@ -34,6 +36,16 @@ func initialPhpSteps(ls labels.LabelSet) []config.Step {
 	return []config.Step{checkout, installPackages}
 }
 
+func phpImageVersion(composerVersion string) string {
+	version := "8.2.7"
+	if composerVersion != "" {
+		version = strings.TrimPrefix(composerVersion, "~")
+		version = strings.TrimPrefix(version, "^")
+		version = strings.TrimSuffix(version, ".*")
+	}
+	return "cimg/php:" + version + "-node"
+}
+
 func phpTestJob(ls labels.LabelSet) *Job {
 	steps := initialPhpSteps(ls)
 	steps = append(steps, config.Step{
@@ -46,7 +58,7 @@ func phpTestJob(ls labels.LabelSet) *Job {
 			Name:         "test-php",
 			Comment:      "Install php packages and run tests",
 			Steps:        steps,
-			DockerImages: []string{"cimg/php:8.2.7-node"},
+			DockerImages: []string{phpImageVersion(ls[labels.DepsPhp].Dependencies["php"])},
 		},
 		Orbs: map[string]string{
 			"php": "circleci/php@1",

--- a/generation/internal/php_test.go
+++ b/generation/internal/php_test.go
@@ -54,6 +54,43 @@ func TestGeneratePHPJobs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "composer file has phpunit and php version",
+			args: args{ls: labels.LabelSet{
+				labels.DepsPhp: labels.Label{
+					Valid: true,
+					LabelData: labels.LabelData{
+						Dependencies: map[string]string{"phpunit/phpunit": "~4.2", "php": "^8.1"},
+						HasLockFile:  true,
+					},
+				}}},
+			wantJobs: []*Job{
+				{
+					Job: config.Job{
+						Name:             "test-php",
+						Comment:          "Install php packages and run tests",
+						WorkingDirectory: "",
+						DockerImages:     []string{"cimg/php:8.1-node"},
+						Steps: []config.Step{
+							{
+								Path: "~/project",
+								Type: config.Checkout,
+							},
+							{
+								Command: "php/install-packages",
+								Type:    config.OrbCommand,
+							},
+							{
+								Type:    config.Run,
+								Name:    "run tests",
+								Command: "./vendor/bin/phpunit",
+							},
+						}},
+					Type: TestJob,
+					Orbs: map[string]string{"php": "circleci/php@1"},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -64,6 +101,29 @@ func TestGeneratePHPJobs(t *testing.T) {
 				t.Errorf("MakeGatewayInfo() mismatch (-want +got):\n%s", diff)
 			}
 
+		})
+	}
+}
+
+func Test_phpImageVersion(t *testing.T) {
+	type args struct {
+		composerVersion string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{"explicit version", args{"8.1.2"}, "cimg/php:8.1.2-node"},
+		{"caret version", args{"^8.1.2"}, "cimg/php:8.1.2-node"},
+		{"wildcard version", args{"8.1.*"}, "cimg/php:8.1-node"},
+		{"~ version", args{"~8.1.2"}, "cimg/php:8.1.2-node"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := phpImageVersion(tt.args.composerVersion); got != tt.want {
+				t.Errorf("phpImageVersion() = %v, want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/generation/internal/php_test.go
+++ b/generation/internal/php_test.go
@@ -114,10 +114,10 @@ func Test_phpImageVersion(t *testing.T) {
 		args args
 		want string
 	}{
-		{"explicit version", args{"8.1.2"}, "cimg/php:8.1.2-node"},
-		{"caret version", args{"^8.1.2"}, "cimg/php:8.1.2-node"},
+		{"explicit version", args{"8.1.2"}, "cimg/php:8.1-node"},
+		{"caret version", args{"^8.1.2"}, "cimg/php:8.1-node"},
 		{"wildcard version", args{"8.1.*"}, "cimg/php:8.1-node"},
-		{"~ version", args{"~8.1.2"}, "cimg/php:8.1.2-node"},
+		{"~ version", args{"~8.1.2"}, "cimg/php:8.1-node"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
PHP projects may optionally provide the required php version in the composer.json file. 

When present, we'll use that docker version's docker image for running tests.