### PR TITLE
detect other cicd setups and add stub steps

### DIFF
--- a/cmd/inferconfig/testdata/expected/sample-php-laravel.yml
+++ b/cmd/inferconfig/testdata/expected/sample-php-laravel.yml
@@ -1,5 +1,5 @@
 # This config was automatically generated from your source code
-# Stacks detected: deps:node:.,deps:php:.
+# Stacks detected: cicd:jenkins:laradock/jenkins,deps:node:.,deps:php:.
 version: 2.1
 orbs:
   php: circleci/php@1
@@ -23,6 +23,9 @@ jobs:
       - run:
           name: deploy
           command: '#e.g. ./deploy.sh'
+      - run:
+          name: found jenkins config
+          command: ':'
 workflows:
   build-and-test:
     jobs:

--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -809,9 +809,16 @@ workflows:
 					Key:   labels.ToolGradle,
 					Valid: true,
 				},
+				labels.CICDGithubActions: labels.Label{
+					Key:   labels.CICDGithubActions,
+					Valid: true,
+					LabelData: labels.LabelData{
+						BasePath: ".github/workflows",
+					},
+				},
 			},
 			expected: `# This config was automatically generated from your source code
-# Stacks detected: deps:java:.,tool:gradle:
+# Stacks detected: cicd:github-actions:.github/workflows,deps:java:.,tool:gradle:
 version: 2.1
 jobs:
   test-java:
@@ -845,6 +852,9 @@ jobs:
       - run:
           name: deploy
           command: '#e.g. ./deploy.sh'
+      - run:
+          name: found github actions config
+          command: ':'
 workflows:
   build-and-test:
     jobs:

--- a/generation/internal/jobs.go
+++ b/generation/internal/jobs.go
@@ -30,7 +30,7 @@ func BuildConfig(ls labels.LabelSet, jobs []*Job) config.Config {
 		return fallbackConfig
 	}
 
-	jobs = addStubJobs(jobs)
+	jobs = addStubJobs(ls, jobs)
 
 	// Can jobs not just be "cast" to []*config.Jobs somehow?
 	configJobs := make([]*config.Job, len(jobs))
@@ -49,7 +49,30 @@ func BuildConfig(ls labels.LabelSet, jobs []*Job) config.Config {
 	}
 }
 
-func addStubJobs(jobs []*Job) []*Job {
+func getCICDSteps(ls labels.LabelSet) []config.Step {
+	steps := make([]config.Step, 0)
+
+	cicdStepMap := map[string]string{
+		labels.CICDGithubActions:  "github actions",
+		labels.CICDGitlabWorkflow: "github workflows",
+		labels.CICDJenkins:        "jenkins",
+	}
+
+	for label, cicdName := range cicdStepMap {
+		if ciLabel, ok := ls[label]; ok && ciLabel.Valid {
+			steps = append(steps, config.Step{
+				Type:    config.Run,
+				Name:    fmt.Sprintf("found %s config", cicdName),
+				Command: ":", // dont do anything just return status 0 and continue
+			})
+		}
+
+	}
+
+	return steps
+}
+
+func addStubJobs(ls labels.LabelSet, jobs []*Job) []*Job {
 	jobTypesPresent := map[Type]bool{}
 
 	for _, j := range jobs {
@@ -60,7 +83,11 @@ func addStubJobs(jobs []*Job) []*Job {
 		jobs = append(jobs, &stubTestJob)
 	}
 	if !jobTypesPresent[DeployJob] {
-		jobs = append(jobs, &stubDeployJob)
+		deployJob := stubDeployJob
+		deployJob.Steps = stubDeployJob.Steps
+		deployJob.Steps = append(deployJob.Steps, getCICDSteps(ls)...)
+
+		jobs = append(jobs, &deployJob)
 	}
 
 	return jobs

--- a/labeling/internal/github.go
+++ b/labeling/internal/github.go
@@ -1,0 +1,18 @@
+package internal
+
+import (
+	"path"
+
+	"github.com/CircleCI-Public/circleci-config/labeling/codebase"
+	"github.com/CircleCI-Public/circleci-config/labeling/labels"
+)
+
+var GithubActionRules = []labels.Rule{
+	func(c codebase.Codebase, ls labels.LabelSet) (label labels.Label, err error) {
+		label.Key = labels.CICDGithubActions
+		configPath, err := c.FindFile(".github/workflows/*yml")
+		label.Valid = configPath != ""
+		label.BasePath = path.Dir(configPath)
+		return label, err
+	},
+}

--- a/labeling/internal/gitlab.go
+++ b/labeling/internal/gitlab.go
@@ -1,0 +1,18 @@
+package internal
+
+import (
+	"path"
+
+	"github.com/CircleCI-Public/circleci-config/labeling/codebase"
+	"github.com/CircleCI-Public/circleci-config/labeling/labels"
+)
+
+var GitlabWorkflowRules = []labels.Rule{
+	func(c codebase.Codebase, ls labels.LabelSet) (label labels.Label, err error) {
+		label.Key = labels.CICDGitlabWorkflow
+		configPath, err := c.FindFile(".gitlab-ci.yml")
+		label.Valid = configPath != ""
+		label.BasePath = path.Dir(configPath)
+		return label, err
+	},
+}

--- a/labeling/internal/jenkins.go
+++ b/labeling/internal/jenkins.go
@@ -1,0 +1,18 @@
+package internal
+
+import (
+	"path"
+
+	"github.com/CircleCI-Public/circleci-config/labeling/codebase"
+	"github.com/CircleCI-Public/circleci-config/labeling/labels"
+)
+
+var JenkinsRules = []labels.Rule{
+	func(c codebase.Codebase, ls labels.LabelSet) (label labels.Label, err error) {
+		label.Key = labels.CICDJenkins
+		configPath, err := c.FindFile("Jenkinsfile")
+		label.Valid = configPath != ""
+		label.BasePath = path.Dir(configPath)
+		return label, err
+	},
+}

--- a/labeling/labeling.go
+++ b/labeling/labeling.go
@@ -35,6 +35,9 @@ func ApplyAllRules(c codebase.Codebase) labels.LabelSet {
 		internal.RubyRules,
 		internal.RustRules,
 		internal.PhpRules,
+		internal.GithubActionRules,
+		internal.GitlabWorkflowRules,
+		internal.JenkinsRules,
 		// Add other stacks here
 	}
 

--- a/labeling/labels/labels.go
+++ b/labeling/labels/labels.go
@@ -22,6 +22,9 @@ const (
 	PackageManagerPoetry  = "package_manager:poetry"
 	PackageManagerYarn    = "package_manager:yarn"
 	PackageManagerGemspec = "package_manager:gemspec"
+	CICDGithubActions     = "cicd:github-actions"
+	CICDGitlabWorkflow    = "cicd:gitlab-worfklows"
+	CICDJenkins           = "cicd:jenkins"
 	TestJest              = "test:jest"
 	ToolGradle            = "tool:gradle"
 	FileManagePy          = "file:manage.py"
@@ -53,11 +56,9 @@ func (label Label) String() string {
 type LabelSet map[string]Label
 
 func (ls LabelSet) String() string {
-	labelsAsStrings := make([]string, len(ls))
-	i := 0
+	labelsAsStrings := make([]string, 0, len(ls))
 	for _, v := range ls {
-		labelsAsStrings[i] = v.String()
-		i++
+		labelsAsStrings = append(labelsAsStrings, v.String())
 	}
 	sort.Strings(labelsAsStrings)
 	return strings.Join(labelsAsStrings, ",")


### PR DESCRIPTION
This PR will detect if there are other ci/cd setups present in the repo and create stub steps. Currently it will search for:
- jenkins:  by searching for a `Jenkinsfile` file
- github actions: by searching for presence of a yaml file in `.github/workflows`
- gitlab workflows: by searching for `.gitlab-ci.yml` file.