### PR TITLE
include cicd steps on fallback config

### DIFF
--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -44,7 +44,7 @@ func TestGenerateConfig(t *testing.T) {
 			testName: "no labels generates fallback config",
 			labels:   labels.LabelSet{},
 			expected: `# Couldn't automatically generate a config from your source code.
-# This is generic template to serve as a base for your custom config
+# This is a generic template to serve as a base for your custom config
 # See: https://circleci.com/docs/configuration-reference
 version: 2.1
 jobs:
@@ -102,7 +102,7 @@ workflows:
 				},
 			},
 			expected: `# Couldn't automatically generate a config from your source code.
-# This is generic template to serve as a base for your custom config
+# This is a generic template to serve as a base for your custom config
 # See: https://circleci.com/docs/configuration-reference
 # Stacks detected: cicd:github-actions:.
 version: 2.1

--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -69,7 +69,6 @@ jobs:
       - store_artifacts:
           path: example.txt
   deploy:
-    # This is an example deploy job, not actually used by the workflow
     docker:
       - image: cimg/base:stable
     steps:
@@ -128,7 +127,6 @@ jobs:
       - store_artifacts:
           path: example.txt
   deploy:
-    # This is an example deploy job, not actually used by the workflow
     docker:
       - image: cimg/base:stable
     steps:

--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -88,7 +88,70 @@ workflows:
           requires:
             - test
 `,
-		}, {
+		},
+
+		{
+			testName: "cicd included in fallback config",
+			labels: labels.LabelSet{
+				labels.CICDGithubActions: labels.Label{
+					Key:   labels.CICDGithubActions,
+					Valid: true,
+					LabelData: labels.LabelData{
+						BasePath: ".",
+					},
+				},
+			},
+			expected: `# Couldn't automatically generate a config from your source code.
+# This is generic template to serve as a base for your custom config
+# See: https://circleci.com/docs/configuration-reference
+# Stacks detected: cicd:github-actions:.
+version: 2.1
+jobs:
+  test:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      # Replace this with a real test runner invocation
+      - run:
+          name: Run tests
+          command: echo 'replace me with real tests!' && false
+  build:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      # Replace this with steps to build a package, or executable
+      - run:
+          name: Build an artifact
+          command: touch example.txt
+      - store_artifacts:
+          path: example.txt
+  deploy:
+    # This is an example deploy job, not actually used by the workflow
+    docker:
+      - image: cimg/base:stable
+    steps:
+      # Replace this with steps to deploy to users
+      - run:
+          name: deploy
+          command: '#e.g. ./deploy.sh'
+      - run:
+          name: found github actions config
+          command: ':'
+workflows:
+  example:
+    jobs:
+      - test
+      - build:
+          requires:
+            - test
+      - deploy:
+          requires:
+            - test
+`,
+		},
+		{
 			testName: "node and go codebases in subdirs",
 			labels: labels.LabelSet{
 				labels.DepsNode: labels.Label{

--- a/generation/internal/fallback.go
+++ b/generation/internal/fallback.go
@@ -59,34 +59,3 @@ var stubDeployJob = Job{
 	},
 	Type: DeployJob,
 }
-
-var fallbackConfig = config.Config{
-	Comment: `Couldn't automatically generate a config from your source code.
-This is generic template to serve as a base for your custom config
-See: https://circleci.com/docs/configuration-reference`,
-	Jobs: []*config.Job{
-		&stubTestJob.Job,
-		&stubArtifactJob.Job,
-		&stubDeployJob.Job,
-	},
-	Workflows: []*config.Workflow{
-		{
-			Name: "example",
-			Jobs: []config.WorkflowJob{
-				{
-					Job: &stubTestJob.Job,
-				}, {
-					Job: &stubArtifactJob.Job,
-					Requires: []*config.Job{
-						&stubTestJob.Job,
-					},
-				}, {
-					Job: &stubDeployJob.Job,
-					Requires: []*config.Job{
-						&stubTestJob.Job,
-					},
-				},
-			},
-		},
-	},
-}

--- a/generation/internal/jobs.go
+++ b/generation/internal/jobs.go
@@ -59,6 +59,7 @@ func buildDeployJob(ls labels.LabelSet) *Job {
 
 func buildFallbackConfig(ls labels.LabelSet) config.Config {
 	deployJob := buildDeployJob(ls)
+	deployJob.Comment = ""
 
 	comment := `Couldn't automatically generate a config from your source code.
 This is a generic template to serve as a base for your custom config

--- a/generation/internal/jobs.go
+++ b/generation/internal/jobs.go
@@ -61,7 +61,7 @@ func buildFallbackConfig(ls labels.LabelSet) config.Config {
 	deployJob := buildDeployJob(ls)
 
 	comment := `Couldn't automatically generate a config from your source code.
-This is generic template to serve as a base for your custom config
+This is a generic template to serve as a base for your custom config
 See: https://circleci.com/docs/configuration-reference`
 	if len(ls) > 0 {
 		comment = fmt.Sprintf("%s\n"+


### PR DESCRIPTION
The CICD steps only gets added if we detected labels. This PR will  add the capability to detect and add those steps on fallback configs.