### PR TITLE
(CVL-598) Remove setup.py from label list

### DIFF
--- a/labeling/internal/python.go
+++ b/labeling/internal/python.go
@@ -24,7 +24,6 @@ var possiblePythonFiles = append(
 		[]string{
 			"requirements.txt",
 			"pyproject.toml",
-			"setup.py",
 			"manage.py",
 		},
 		pipenvFiles...,


### PR DESCRIPTION
After looking into failing python inference projects we found several instances of a project being labeled as python while only containing .1% python code. 

We found that there are instances were there is some python code present, including a setup.py file, but that can not be relied on alone to determine that the project is a python project so we are removing the file from the label list.