### PR TITLE
Skip downloading go modules when there's no lockfile

### DIFF
--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -160,7 +160,7 @@ workflows:
 				labels.DepsGo: labels.Label{
 					Key:       labels.DepsGo,
 					Valid:     true,
-					LabelData: labels.LabelData{BasePath: "go-dir"},
+					LabelData: labels.LabelData{BasePath: "go-dir", HasLockFile: true},
 				}},
 			expected: `# This config was automatically generated from your source code
 # Stacks detected: deps:go:go-dir,deps:node:node-dir
@@ -941,6 +941,50 @@ workflows:
     # - deploy:
     #     requires:
     #       - test-java
+`,
+		},
+
+		{
+			testName: "go codebase without lockfile",
+			labels: labels.LabelSet{
+				labels.DepsGo: labels.Label{
+					Key:       labels.DepsGo,
+					Valid:     true,
+					LabelData: labels.LabelData{BasePath: "go-dir", HasLockFile: false},
+				}},
+			expected: `# This config was automatically generated from your source code
+# Stacks detected: deps:go:go-dir
+version: 2.1
+jobs:
+  test-go:
+    # Install go modules and run tests
+    docker:
+      - image: cimg/go:1.20
+    working_directory: ~/project/go-dir
+    steps:
+      - checkout:
+          path: ~/project
+      - run:
+          name: Run tests
+          command: gotestsum --junitfile junit.xml
+      - store_test_results:
+          path: junit.xml
+  deploy:
+    # This is an example deploy job, not actually used by the workflow
+    docker:
+      - image: cimg/base:stable
+    steps:
+      # Replace this with steps to deploy to users
+      - run:
+          name: deploy
+          command: '#e.g. ./deploy.sh'
+workflows:
+  build-and-test:
+    jobs:
+      - test-go
+    # - deploy:
+    #     requires:
+    #       - test-go
 `,
 		},
 	}

--- a/labeling/internal/go.go
+++ b/labeling/internal/go.go
@@ -15,6 +15,8 @@ var GoRules = []labels.Rule{
 		goModPath, err := c.FindFile("go.mod")
 		label.Valid = goModPath != ""
 		label.BasePath = path.Dir(goModPath)
+		lockFilePath, _ := c.FindFile("go.sum")
+		label.LabelData.HasLockFile = lockFilePath != ""
 		return label, err
 	},
 	func(c codebase.Codebase, ls labels.LabelSet) (label labels.Label, err error) {

--- a/labeling/labeling_test.go
+++ b/labeling/labeling_test.go
@@ -282,12 +282,14 @@ func TestCodebase_ApplyRules_Go(t *testing.T) {
 			name: "go.mod => deps:go",
 			files: map[string]string{
 				"go.mod": "module mymod\n\ngo 1.18\n",
+				"go.sum": "",
 			},
 			expectedLabels: []labels.Label{
 				{
 					Key: labels.DepsGo,
 					LabelData: labels.LabelData{
-						BasePath: ".",
+						BasePath:    ".",
+						HasLockFile: true,
 					},
 				},
 			},
@@ -340,13 +342,15 @@ func TestCodebase_ApplyRules_Go(t *testing.T) {
 			name: "go.mod & go main package in subdir of cmd => artifact:go-executable",
 			files: map[string]string{
 				"go.mod":        "module mymod\n\ngo 1.18\n",
+				"go.sum":        "",
 				"cmd/x/main.go": "//this is package main\npackage main",
 			},
 			expectedLabels: []labels.Label{
 				{
 					Key: labels.DepsGo,
 					LabelData: labels.LabelData{
-						BasePath: ".",
+						BasePath:    ".",
+						HasLockFile: true,
 					},
 				}, {
 					Key: labels.ArtifactGoExecutable,
@@ -358,6 +362,15 @@ func TestCodebase_ApplyRules_Go(t *testing.T) {
 				"main.go": "package main",
 			},
 			expectedLabels: []labels.Label{},
+		},
+		{
+			name: "go.mod but not go.sum",
+			files: map[string]string{
+				"go.mod": "module github.com/circleci-public/foobar\ngo 1.20",
+			},
+			expectedLabels: []labels.Label{
+				{Key: labels.DepsGo, LabelData: labels.LabelData{BasePath: "."}},
+			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
If the repo has a `go.mod`, but no external dependencies (no `go.sum`), skip downloading and caching steps.