### PR TITLE
(CVL-599) Remove package-manager logic

### DIFF
--- a/cmd/inferconfig/testdata/expected/circleci-demo-python-django.yml
+++ b/cmd/inferconfig/testdata/expected/circleci-demo-python-django.yml
@@ -10,12 +10,10 @@ jobs:
       - image: cimg/python:3.8-node
     steps:
       - checkout
-      - python/install-packages:
-          args: --dev
-          pkg-manager: pipenv
+      - python/install-packages
       - run:
           name: Run tests
-          command: pipenv run python manage.py test
+          command: python manage.py test
   deploy:
     # This is an example deploy job, not actually used by the workflow
     docker:

--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -505,11 +505,10 @@ jobs:
       - image: cimg/python:3.8-node
     steps:
       - checkout
-      - python/install-packages:
-          pkg-manager: poetry
+      - python/install-packages
       - run:
           name: Run tests
-          command: poetry run pytest --junitxml=junit.xml
+          command: pytest --junitxml=junit.xml
       - store_test_results:
           path: junit.xml
   deploy:
@@ -558,11 +557,10 @@ jobs:
     steps:
       - checkout:
           path: ~/project
-      - python/install-packages:
-          pkg-manager: poetry
+      - python/install-packages
       - run:
           name: Run tests
-          command: poetry run pytest --junitxml=junit.xml
+          command: pytest --junitxml=junit.xml
       - store_test_results:
           path: junit.xml
   deploy:
@@ -666,12 +664,10 @@ jobs:
       - image: cimg/python:3.8-node
     steps:
       - checkout
-      - python/install-packages:
-          args: --dev
-          pkg-manager: pipenv
+      - python/install-packages
       - run:
           name: Run tests
-          command: pipenv run python manage.py test
+          command: python manage.py test
   deploy:
     # This is an example deploy job, not actually used by the workflow
     docker:
@@ -723,11 +719,10 @@ jobs:
       - image: cimg/python:3.8-node
     steps:
       - checkout
-      - python/install-packages:
-          pkg-manager: poetry
+      - python/install-packages
       - run:
           name: Run tests
-          command: poetry run python manage.py test
+          command: python manage.py test
   deploy:
     # This is an example deploy job, not actually used by the workflow
     docker:
@@ -782,12 +777,10 @@ jobs:
       - image: cimg/python:3.1.1-node
     steps:
       - checkout
-      - python/install-packages:
-          args: --dev
-          pkg-manager: pipenv
+      - python/install-packages
       - run:
           name: Run tests
-          command: pipenv run pytest --junitxml=junit.xml
+          command: pytest --junitxml=junit.xml
       - store_test_results:
           path: junit.xml
   deploy:

--- a/generation/internal/python.go
+++ b/generation/internal/python.go
@@ -26,15 +26,6 @@ func defaultSteps(l labels.Label, hasManagePy bool) []config.Step {
 
 	steps = append(steps, []config.Step{
 		{
-			Type:    config.OrbCommand,
-			Command: "python/install-packages",
-			Parameters: config.OrbCommandParameters{
-				"args":        "pytest",
-				"pkg-manager": "pip",
-				"pypi-cache":  "false",
-			},
-		},
-		{
 			Name:    "Run tests",
 			Type:    config.Run,
 			Command: "pytest --junitxml=junit.xml",
@@ -43,78 +34,11 @@ func defaultSteps(l labels.Label, hasManagePy bool) []config.Step {
 	return steps
 }
 
-func pipenvSteps(l labels.Label, hasManagePy bool) []config.Step {
-	steps := []config.Step{
-		{
-			Type:    config.OrbCommand,
-			Command: "python/install-packages",
-			Parameters: config.OrbCommandParameters{
-				"args":        "--dev",
-				"pkg-manager": "pipenv",
-			},
-		},
-	}
-
-	if hasManagePy {
-		steps = append(steps, config.Step{
-			Name:    "Run tests",
-			Type:    config.Run,
-			Command: "pipenv run python manage.py test",
-		})
-		return steps
-	}
-
-	steps = append(steps, config.Step{
-		Name:    "Run tests",
-		Type:    config.Run,
-		Command: "pipenv run pytest --junitxml=junit.xml",
-	})
-
-	return steps
-}
-
-func poetrySteps(l labels.Label, hasManagerPy bool) []config.Step {
-	steps := []config.Step{
-		{
-			Type:    config.OrbCommand,
-			Command: "python/install-packages",
-			Parameters: config.OrbCommandParameters{
-				"pkg-manager": "poetry",
-			},
-		},
-	}
-
-	if hasManagerPy {
-		steps = append(steps, config.Step{
-			Name:    "Run tests",
-			Type:    config.Run,
-			Command: "poetry run python manage.py test",
-		})
-		return steps
-	}
-
-	steps = append(steps, config.Step{
-		Name:    "Run tests",
-		Type:    config.Run,
-		Command: "poetry run pytest --junitxml=junit.xml",
-	})
-
-	return steps
-}
-
 func pythonTestJob(ls labels.LabelSet) *Job {
 	steps := []config.Step{checkoutStep(ls[labels.DepsPython])}
 	hasManagePy := ls[labels.FileManagePy].Valid
 
-	// Support for different package managers
-	switch {
-	case ls[labels.PackageManagerPipenv].Valid:
-		steps = append(steps, pipenvSteps(ls[labels.PackageManagerPipenv], hasManagePy)...)
-	case ls[labels.PackageManagerPoetry].Valid:
-		steps = append(steps, poetrySteps(ls[labels.PackageManagerPoetry], hasManagePy)...)
-	default:
-		steps = append(steps, defaultSteps(ls[labels.DepsPython], hasManagePy)...)
-	}
+	steps = append(steps, defaultSteps(ls[labels.DepsPython], hasManagePy)...)
 
 	if !hasManagePy {
 		// Store test results


### PR DESCRIPTION
We previously were trying to determine the python package manager in two places, here and within the python-orb. To keep consistent, remove the package manager code from here and just use the logic in the python orb.

See: https://github.com/CircleCI-Public/python-orb/pull/116

This cannot be merged until the python-orb changes are merged.

Tested this with a dev version of the python orb and generated configs from a python project.