### PR TITLE
When using pytest, do not fail build if no tests found

### DIFF
--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -513,7 +513,7 @@ jobs:
           pkg-manager: poetry
       - run:
           name: Run tests
-          command: poetry run pytest --junitxml=junit.xml
+          command: poetry run pytest --junitxml=junit.xml || ((($? == 5)) && echo 'Did not find any tests to run.')
       - store_test_results:
           path: junit.xml
   deploy:
@@ -566,7 +566,7 @@ jobs:
           pkg-manager: poetry
       - run:
           name: Run tests
-          command: poetry run pytest --junitxml=junit.xml
+          command: poetry run pytest --junitxml=junit.xml || ((($? == 5)) && echo 'Did not find any tests to run.')
       - store_test_results:
           path: junit.xml
   deploy:
@@ -791,7 +791,7 @@ jobs:
           pkg-manager: pipenv
       - run:
           name: Run tests
-          command: pipenv run pytest --junitxml=junit.xml
+          command: pipenv run pytest --junitxml=junit.xml || ((($? == 5)) && echo 'Did not find any tests to run.')
       - store_test_results:
           path: junit.xml
   deploy:

--- a/generation/internal/python.go
+++ b/generation/internal/python.go
@@ -37,7 +37,7 @@ func defaultSteps(l labels.Label, hasManagePy bool) []config.Step {
 		{
 			Name:    "Run tests",
 			Type:    config.Run,
-			Command: "pytest --junitxml=junit.xml",
+			Command: "pytest --junitxml=junit.xml || ((($? == 5)) && echo 'Did not find any tests to run.')",
 		}}...)
 
 	return steps
@@ -67,7 +67,7 @@ func pipenvSteps(l labels.Label, hasManagePy bool) []config.Step {
 	steps = append(steps, config.Step{
 		Name:    "Run tests",
 		Type:    config.Run,
-		Command: "pipenv run pytest --junitxml=junit.xml",
+		Command: "pipenv run pytest --junitxml=junit.xml || ((($? == 5)) && echo 'Did not find any tests to run.')",
 	})
 
 	return steps
@@ -96,7 +96,7 @@ func poetrySteps(l labels.Label, hasManagerPy bool) []config.Step {
 	steps = append(steps, config.Step{
 		Name:    "Run tests",
 		Type:    config.Run,
-		Command: "poetry run pytest --junitxml=junit.xml",
+		Command: "poetry run pytest --junitxml=junit.xml || ((($? == 5)) && echo 'Did not find any tests to run.')",
 	})
 
 	return steps


### PR DESCRIPTION
Rather than fail a build without any tests, catch the error code pytest returns (5) and show a message instead.

