### PR TITLE
Support installing with setup.py and running tests with tox

### DIFF
--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -751,6 +751,67 @@ workflows:
 `,
 		},
 		{
+			testName: "python project with a setup.py and tox",
+			labels: labels.LabelSet{
+				labels.DepsPython: labels.Label{
+					Key:   labels.DepsPython,
+					Valid: true,
+					LabelData: labels.LabelData{
+						BasePath: ".",
+					},
+				},
+				labels.FileSetupPy: labels.Label{
+					Key:       labels.FileSetupPy,
+					Valid:     true,
+					LabelData: labels.LabelData{BasePath: "."},
+				},
+				labels.FileToxIni: labels.Label{
+					Key:       labels.FileToxIni,
+					Valid:     true,
+					LabelData: labels.LabelData{BasePath: "."},
+				},
+			},
+			expected: `# This config was automatically generated from your source code
+# Stacks detected: deps:python:.,file:setup.py:.,file:tox.ini:.
+version: 2.1
+orbs:
+  python: circleci/python@2
+jobs:
+  test-python:
+    # Install dependencies and run tests
+    docker:
+      - image: cimg/python:3.8-node
+    steps:
+      - checkout
+      - python/install-packages:
+          pkg-manager: pip-dist
+      - python/install-packages:
+          args: tox
+          pkg-manager: pip-dist
+      - run:
+          name: Run tests
+          command: tox
+      - store_test_results:
+          path: junit.xml
+  deploy:
+    # This is an example deploy job, not actually used by the workflow
+    docker:
+      - image: cimg/base:stable
+    steps:
+      # Replace this with steps to deploy to users
+      - run:
+          name: deploy
+          command: '#e.g. ./deploy.sh'
+workflows:
+  build-and-test:
+    jobs:
+      - test-python
+    # - deploy:
+    #     requires:
+    #       - test-python
+`,
+		},
+		{
 			testName: "python project with a .python-version file",
 			labels: labels.LabelSet{
 				labels.DepsPython: labels.Label{

--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -765,14 +765,14 @@ workflows:
 					Valid:     true,
 					LabelData: labels.LabelData{BasePath: "."},
 				},
-				labels.FileToxIni: labels.Label{
-					Key:       labels.FileToxIni,
+				labels.TestTox: labels.Label{
+					Key:       labels.TestTox,
 					Valid:     true,
 					LabelData: labels.LabelData{BasePath: "."},
 				},
 			},
 			expected: `# This config was automatically generated from your source code
-# Stacks detected: deps:python:.,file:setup.py:.,file:tox.ini:.
+# Stacks detected: deps:python:.,file:setup.py:.,test:tox:.
 version: 2.1
 orbs:
   python: circleci/python@2

--- a/generation/internal/python.go
+++ b/generation/internal/python.go
@@ -10,7 +10,7 @@ const pythonOrb = "circleci/python@2"
 func testSteps(ls labels.LabelSet) []config.Step {
 	hasManagePy := ls[labels.FileManagePy].Valid
 	hasSetupPy := ls[labels.FileSetupPy].Valid
-	hasTox := ls[labels.FileToxIni].Valid
+	hasTox := ls[labels.TestTox].Valid
 	hasPipenv := ls[labels.PackageManagerPipenv].Valid
 	hasPoetry := ls[labels.PackageManagerPoetry].Valid
 

--- a/labeling/internal/python.go
+++ b/labeling/internal/python.go
@@ -103,7 +103,7 @@ var PythonRules = []labels.Rule{
 		return label, nil
 	},
 	func(c codebase.Codebase, ls labels.LabelSet) (labels.Label, error) {
-		label := labels.Label{Key: labels.FileToxIni}
+		label := labels.Label{Key: labels.TestTox}
 		toxPath, _ := c.FindFile("tox.ini")
 		label.Valid = toxPath != ""
 		label.BasePath = path.Dir(toxPath)

--- a/labeling/internal/python.go
+++ b/labeling/internal/python.go
@@ -27,6 +27,7 @@ var possiblePythonFiles = append(
 			"requirements.txt",
 			"pyproject.toml",
 			"manage.py",
+			"setup.py",
 		},
 		pipenvFiles...,
 	),
@@ -90,6 +91,22 @@ var PythonRules = []labels.Rule{
 		managePyPath, _ := c.FindFile("manage.py")
 		label.Valid = managePyPath != ""
 		label.BasePath = path.Dir(managePyPath)
+		return label, nil
+	},
+	func(c codebase.Codebase, ls labels.LabelSet) (labels.Label, error) {
+		label := labels.Label{
+			Key: labels.FileSetupPy,
+		}
+		setupPath, _ := c.FindFile("setup.py")
+		label.Valid = setupPath != ""
+		label.BasePath = path.Dir(setupPath)
+		return label, nil
+	},
+	func(c codebase.Codebase, ls labels.LabelSet) (labels.Label, error) {
+		label := labels.Label{Key: labels.FileToxIni}
+		toxPath, _ := c.FindFile("tox.ini")
+		label.Valid = toxPath != ""
+		label.BasePath = path.Dir(toxPath)
 		return label, nil
 	},
 }

--- a/labeling/labels/labels.go
+++ b/labeling/labels/labels.go
@@ -28,6 +28,8 @@ const (
 	TestJest              = "test:jest"
 	ToolGradle            = "tool:gradle"
 	FileManagePy          = "file:manage.py"
+	FileSetupPy           = "file:setup.py"
+	FileToxIni            = "file:tox.ini"
 )
 
 type LabelData struct {

--- a/labeling/labels/labels.go
+++ b/labeling/labels/labels.go
@@ -29,7 +29,7 @@ const (
 	ToolGradle            = "tool:gradle"
 	FileManagePy          = "file:manage.py"
 	FileSetupPy           = "file:setup.py"
-	FileToxIni            = "file:tox.ini"
+	TestTox               = "test:tox"
 )
 
 type LabelData struct {


### PR DESCRIPTION
This will support python projects that use setuptools for installing dependencies (instead of pipenv and poetry).

It will also enable running tests with tox. 
