### PR TITLE
(CVL-622) Update jest command

### DIFF
--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -312,7 +312,7 @@ jobs:
           command: yarn add jest-junit
       - run:
           name: Run tests with Jest
-          command: jest --ci --runInBand --reporters=default --reporters=jest-junit
+          command: ./node_modules/.bin/jest --ci --runInBand --reporters=default --reporters=jest-junit
       - store_test_results:
           path: ./test-results/
   deploy:
@@ -410,7 +410,7 @@ jobs:
           command: npm install jest-junit
       - run:
           name: Run tests with Jest
-          command: jest --ci --runInBand --reporters=default --reporters=jest-junit
+          command: ./node_modules/.bin/jest --ci --runInBand --reporters=default --reporters=jest-junit
       - store_test_results:
           path: ./test-results/
   deploy:

--- a/generation/internal/node.go
+++ b/generation/internal/node.go
@@ -91,7 +91,7 @@ func nodeTestSteps(ls labels.LabelSet) []config.Step {
 		return []config.Step{{
 			Type:    config.Run,
 			Name:    "Run tests with Jest",
-			Command: "jest --ci --runInBand --reporters=default --reporters=jest-junit",
+			Command: "./node_modules/.bin/jest --ci --runInBand --reporters=default --reporters=jest-junit",
 		}}
 	}
 


### PR DESCRIPTION
Update jest call from `jest` to `./node_modules/.bin/jest`

Tested this by cloning one of the repos that had failed with the `command not found: jest` error. Confirmed that it failed with just `jest` and then ran with `./node_modules/.bin/jest` and it ran properly
