### PR TITLE
(CVL-623) Add --passWithNoTests flag to node test step

### DIFF
--- a/cmd/inferconfig/testdata/expected/circleci-demo-javascript-express.yml
+++ b/cmd/inferconfig/testdata/expected/circleci-demo-javascript-express.yml
@@ -13,7 +13,7 @@ jobs:
           pkg-manager: npm
       - run:
           name: Run tests
-          command: npm test
+          command: npm test --passWithNoTests
   build-node:
     # Build node project
     executor: node/default

--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -179,7 +179,7 @@ jobs:
           pkg-manager: npm
       - run:
           name: Run tests
-          command: npm test
+          command: npm test --passWithNoTests
   test-go:
     # Install go modules and run tests
     docker:
@@ -255,7 +255,7 @@ jobs:
           pkg-manager: yarn
       - run:
           name: Run tests
-          command: yarn test
+          command: yarn test --passWithNoTests
   deploy:
     # This is an example deploy job, not actually used by the workflow
     docker:
@@ -358,7 +358,7 @@ jobs:
           override-ci-command: npm install
       - run:
           name: Run tests
-          command: npm test
+          command: npm test --passWithNoTests
   deploy:
     # This is an example deploy job, not actually used by the workflow
     docker:

--- a/generation/internal/node.go
+++ b/generation/internal/node.go
@@ -22,7 +22,7 @@ func nodePackageManager(ls labels.LabelSet) string {
 
 func nodeRunCommand(ls labels.LabelSet, task string) string {
 	if task == "test" {
-		return fmt.Sprintf("%s test", nodePackageManager(ls))
+		return fmt.Sprintf("%s test --passWithNoTests", nodePackageManager(ls))
 	}
 	return fmt.Sprintf("%s run %s", nodePackageManager(ls), task)
 }


### PR DESCRIPTION
Cloned a repo that had errored out with the "no tests found" error/exit 1, adding the flag to the test call allowed it to gracefully exit 0