### PR TITLE
Add build package job for python

### DIFF
--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -793,6 +793,19 @@ jobs:
           command: tox
       - store_test_results:
           path: junit.xml
+  build-package:
+    # build python package
+    docker:
+      - image: cimg/python:3.8-node
+    steps:
+      - checkout
+      - run:
+          name: Create the ~/artifacts directory if it doesn't exist
+          command: mkdir -p ~/artifacts
+      - python/dist
+      - store_artifacts:
+          path: dist
+          destination: ~/artifacts
   deploy:
     # This is an example deploy job, not actually used by the workflow
     docker:
@@ -806,9 +819,12 @@ workflows:
   build-and-test:
     jobs:
       - test-python
+      - build-package:
+          requires:
+            - test-python
     # - deploy:
     #     requires:
-    #       - test-python
+    #       - build-package
 `,
 		},
 		{


### PR DESCRIPTION
This adds a new job, dependent on the test job, for creating a python package and uploading the result.

This follows the same approach currently used for Go. 