### PR TITLE
(CVL-621) Do not fail on default test command

### DIFF
--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -275,6 +275,50 @@ workflows:
 `,
 		},
 		{
+			testName: "node codebase with default test task set",
+			labels: labels.LabelSet{
+				labels.DepsNode: labels.Label{
+					Key:       labels.DepsNode,
+					Valid:     true,
+					LabelData: labels.LabelData{BasePath: ".", HasLockFile: false, Tasks: map[string]string{"test": "echo \"Error: no test specified\" && exit 1"}},
+				},
+			},
+			expected: `# This config was automatically generated from your source code
+# Stacks detected: deps:node:.
+version: 2.1
+orbs:
+  node: circleci/node@5
+jobs:
+  test-node:
+    # Install node dependencies and run tests
+    executor: node/default
+    steps:
+      - checkout
+      - node/install-packages:
+          cache-path: ~/project/node_modules
+          override-ci-command: npm install
+      - run:
+          name: Run tests
+          command: echo \"No test specified in package.json\"
+  deploy:
+    # This is an example deploy job, not actually used by the workflow
+    docker:
+      - image: cimg/base:stable
+    steps:
+      # Replace this with steps to deploy to users
+      - run:
+          name: deploy
+          command: '#e.g. ./deploy.sh'
+workflows:
+  build-and-test:
+    jobs:
+      - test-node
+    # - deploy:
+    #     requires:
+    #       - test-node
+`,
+		},
+		{
 			testName: "node codebase with yarn.lock and .yarnrc.yml file",
 			labels: labels.LabelSet{
 				labels.DepsNode: labels.Label{

--- a/generation/internal/node.go
+++ b/generation/internal/node.go
@@ -22,6 +22,13 @@ func nodePackageManager(ls labels.LabelSet) string {
 
 func nodeRunCommand(ls labels.LabelSet, task string) string {
 	if task == "test" {
+		// don't fail for default test value for new node projects
+		for _, label := range ls {
+			labelData := label.LabelData
+			if labelData.Tasks[task] == "echo \"Error: no test specified\" && exit 1" {
+				return "echo \\\"No test specified in package.json\\\""
+			}
+		}
 		return fmt.Sprintf("%s test", nodePackageManager(ls))
 	}
 	return fmt.Sprintf("%s run %s", nodePackageManager(ls), task)

--- a/generation/internal/node.go
+++ b/generation/internal/node.go
@@ -23,11 +23,8 @@ func nodePackageManager(ls labels.LabelSet) string {
 func nodeRunCommand(ls labels.LabelSet, task string) string {
 	if task == "test" {
 		// don't fail for default test value for new node projects
-		for _, label := range ls {
-			labelData := label.LabelData
-			if labelData.Tasks[task] == "echo \"Error: no test specified\" && exit 1" {
-				return "echo \\\"No test specified in package.json\\\""
-			}
+		if ls[labels.DepsNode].Tasks[task] == "echo \"Error: no test specified\" && exit 1" {
+			return "echo \\\"No test specified in package.json\\\""
 		}
 		return fmt.Sprintf("%s test", nodePackageManager(ls))
 	}


### PR DESCRIPTION
Check for presence of default command: `echo \"Error: no test specified\" && exit 1` and if found, replace test command with helpful message `echo \"No test specified in package.json\`

Added a test with the default task set and confirms it generates the correct config

Also cloned one of the repos that had been previously failing and ran the inferconfig on it and the config was generated properly