### PR TITLE
(CVL-620) Add private package install instructions

### DIFF
--- a/cmd/inferconfig/testdata/expected/circleci-demo-javascript-express.yml
+++ b/cmd/inferconfig/testdata/expected/circleci-demo-javascript-express.yml
@@ -12,6 +12,20 @@ jobs:
       - node/install-packages:
           pkg-manager: npm
       - run:
+          name: Print node install help instructions
+          command: |-
+            echo "One cause for node package install failure is if you have private repositories that it can't reach
+            One way to fix this for private npm packages:
+              1. Use the npm CLI's \"login\" command to create a token (usually saved in your user's \"~/.npmrc\" file)
+                For more info, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=set%20the%20%24npm_token%20environment%20variable%20in%20circleci
+              2. Add a NPM_TOKEN to an org context
+                For info on how to use contexts, see https://circleci.com/docs/contexts/
+              3. Add a .circleci/config.yml to your repository or use this config.yml as a starting template
+              4. Configure the jobs to use the context that includes NPM_TOKEN
+              5. Add a step to inject your NPM_TOKEN environment variable into npm before \"install-packages\"
+                For an example, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=the%20deploy%20job%20has%20several%20steps%20that%20run%20to%20authenticate%20with%20and%20publish%20to"
+          when: on_fail
+      - run:
           name: Run tests
           command: npm test --passWithNoTests
   build-node:
@@ -21,6 +35,20 @@ jobs:
       - checkout
       - node/install-packages:
           pkg-manager: npm
+      - run:
+          name: Print node install help instructions
+          command: |-
+            echo "One cause for node package install failure is if you have private repositories that it can't reach
+            One way to fix this for private npm packages:
+              1. Use the npm CLI's \"login\" command to create a token (usually saved in your user's \"~/.npmrc\" file)
+                For more info, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=set%20the%20%24npm_token%20environment%20variable%20in%20circleci
+              2. Add a NPM_TOKEN to an org context
+                For info on how to use contexts, see https://circleci.com/docs/contexts/
+              3. Add a .circleci/config.yml to your repository or use this config.yml as a starting template
+              4. Configure the jobs to use the context that includes NPM_TOKEN
+              5. Add a step to inject your NPM_TOKEN environment variable into npm before \"install-packages\"
+                For an example, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=the%20deploy%20job%20has%20several%20steps%20that%20run%20to%20authenticate%20with%20and%20publish%20to"
+          when: on_fail
       - run:
           command: npm run build
       - run:

--- a/cmd/inferconfig/testdata/expected/circleci-demo-react-native.yml
+++ b/cmd/inferconfig/testdata/expected/circleci-demo-react-native.yml
@@ -14,6 +14,20 @@ jobs:
       - node/install-packages:
           pkg-manager: yarn
       - run:
+          name: Print node install help instructions
+          command: |-
+            echo "One cause for node package install failure is if you have private repositories that it can't reach
+            One way to fix this for private npm packages:
+              1. Use the npm CLI's \"login\" command to create a token (usually saved in your user's \"~/.npmrc\" file)
+                For more info, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=set%20the%20%24npm_token%20environment%20variable%20in%20circleci
+              2. Add a NPM_TOKEN to an org context
+                For info on how to use contexts, see https://circleci.com/docs/contexts/
+              3. Add a .circleci/config.yml to your repository or use this config.yml as a starting template
+              4. Configure the jobs to use the context that includes NPM_TOKEN
+              5. Add a step to inject your NPM_TOKEN environment variable into npm before \"install-packages\"
+                For an example, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=the%20deploy%20job%20has%20several%20steps%20that%20run%20to%20authenticate%20with%20and%20publish%20to"
+          when: on_fail
+      - run:
           name: Run tests
           command: yarn run test --ci --runInBand --reporters=default --reporters=jest-junit
       - store_test_results:

--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -178,6 +178,20 @@ jobs:
       - node/install-packages:
           pkg-manager: npm
       - run:
+          name: Print node install help instructions
+          command: |-
+            echo "One cause for node package install failure is if you have private repositories that it can't reach
+            One way to fix this for private npm packages:
+              1. Use the npm CLI's \"login\" command to create a token (usually saved in your user's \"~/.npmrc\" file)
+                For more info, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=set%20the%20%24npm_token%20environment%20variable%20in%20circleci
+              2. Add a NPM_TOKEN to an org context
+                For info on how to use contexts, see https://circleci.com/docs/contexts/
+              3. Add a .circleci/config.yml to your repository or use this config.yml as a starting template
+              4. Configure the jobs to use the context that includes NPM_TOKEN
+              5. Add a step to inject your NPM_TOKEN environment variable into npm before \"install-packages\"
+                For an example, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=the%20deploy%20job%20has%20several%20steps%20that%20run%20to%20authenticate%20with%20and%20publish%20to"
+          when: on_fail
+      - run:
           name: Run tests
           command: npm test --passWithNoTests
   test-go:
@@ -254,6 +268,20 @@ jobs:
       - node/install-packages:
           pkg-manager: yarn
       - run:
+          name: Print node install help instructions
+          command: |-
+            echo "One cause for node package install failure is if you have private repositories that it can't reach
+            One way to fix this for private npm packages:
+              1. Use the npm CLI's \"login\" command to create a token (usually saved in your user's \"~/.npmrc\" file)
+                For more info, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=set%20the%20%24npm_token%20environment%20variable%20in%20circleci
+              2. Add a NPM_TOKEN to an org context
+                For info on how to use contexts, see https://circleci.com/docs/contexts/
+              3. Add a .circleci/config.yml to your repository or use this config.yml as a starting template
+              4. Configure the jobs to use the context that includes NPM_TOKEN
+              5. Add a step to inject your NPM_TOKEN environment variable into npm before \"install-packages\"
+                For an example, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=the%20deploy%20job%20has%20several%20steps%20that%20run%20to%20authenticate%20with%20and%20publish%20to"
+          when: on_fail
+      - run:
           name: Run tests
           command: yarn test --passWithNoTests
   deploy:
@@ -309,6 +337,20 @@ jobs:
       - node/install-packages:
           pkg-manager: yarn
       - run:
+          name: Print node install help instructions
+          command: |-
+            echo "One cause for node package install failure is if you have private repositories that it can't reach
+            One way to fix this for private npm packages:
+              1. Use the npm CLI's \"login\" command to create a token (usually saved in your user's \"~/.npmrc\" file)
+                For more info, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=set%20the%20%24npm_token%20environment%20variable%20in%20circleci
+              2. Add a NPM_TOKEN to an org context
+                For info on how to use contexts, see https://circleci.com/docs/contexts/
+              3. Add a .circleci/config.yml to your repository or use this config.yml as a starting template
+              4. Configure the jobs to use the context that includes NPM_TOKEN
+              5. Add a step to inject your NPM_TOKEN environment variable into npm before \"install-packages\"
+                For an example, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=the%20deploy%20job%20has%20several%20steps%20that%20run%20to%20authenticate%20with%20and%20publish%20to"
+          when: on_fail
+      - run:
           command: yarn add jest-junit
       - run:
           name: Run tests with Jest
@@ -356,6 +398,20 @@ jobs:
       - node/install-packages:
           cache-path: ~/project/node_modules
           override-ci-command: npm install
+      - run:
+          name: Print node install help instructions
+          command: |-
+            echo "One cause for node package install failure is if you have private repositories that it can't reach
+            One way to fix this for private npm packages:
+              1. Use the npm CLI's \"login\" command to create a token (usually saved in your user's \"~/.npmrc\" file)
+                For more info, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=set%20the%20%24npm_token%20environment%20variable%20in%20circleci
+              2. Add a NPM_TOKEN to an org context
+                For info on how to use contexts, see https://circleci.com/docs/contexts/
+              3. Add a .circleci/config.yml to your repository or use this config.yml as a starting template
+              4. Configure the jobs to use the context that includes NPM_TOKEN
+              5. Add a step to inject your NPM_TOKEN environment variable into npm before \"install-packages\"
+                For an example, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=the%20deploy%20job%20has%20several%20steps%20that%20run%20to%20authenticate%20with%20and%20publish%20to"
+          when: on_fail
       - run:
           name: Run tests
           command: npm test --passWithNoTests
@@ -407,6 +463,20 @@ jobs:
       - node/install-packages:
           pkg-manager: npm
       - run:
+          name: Print node install help instructions
+          command: |-
+            echo "One cause for node package install failure is if you have private repositories that it can't reach
+            One way to fix this for private npm packages:
+              1. Use the npm CLI's \"login\" command to create a token (usually saved in your user's \"~/.npmrc\" file)
+                For more info, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=set%20the%20%24npm_token%20environment%20variable%20in%20circleci
+              2. Add a NPM_TOKEN to an org context
+                For info on how to use contexts, see https://circleci.com/docs/contexts/
+              3. Add a .circleci/config.yml to your repository or use this config.yml as a starting template
+              4. Configure the jobs to use the context that includes NPM_TOKEN
+              5. Add a step to inject your NPM_TOKEN environment variable into npm before \"install-packages\"
+                For an example, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=the%20deploy%20job%20has%20several%20steps%20that%20run%20to%20authenticate%20with%20and%20publish%20to"
+          when: on_fail
+      - run:
           command: npm install jest-junit
       - run:
           name: Run tests with Jest
@@ -453,6 +523,20 @@ jobs:
       - checkout
       - node/install-packages:
           pkg-manager: npm
+      - run:
+          name: Print node install help instructions
+          command: |-
+            echo "One cause for node package install failure is if you have private repositories that it can't reach
+            One way to fix this for private npm packages:
+              1. Use the npm CLI's \"login\" command to create a token (usually saved in your user's \"~/.npmrc\" file)
+                For more info, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=set%20the%20%24npm_token%20environment%20variable%20in%20circleci
+              2. Add a NPM_TOKEN to an org context
+                For info on how to use contexts, see https://circleci.com/docs/contexts/
+              3. Add a .circleci/config.yml to your repository or use this config.yml as a starting template
+              4. Configure the jobs to use the context that includes NPM_TOKEN
+              5. Add a step to inject your NPM_TOKEN environment variable into npm before \"install-packages\"
+                For an example, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=the%20deploy%20job%20has%20several%20steps%20that%20run%20to%20authenticate%20with%20and%20publish%20to"
+          when: on_fail
       - run:
           command: npm run build
       - run:

--- a/generation/internal/node.go
+++ b/generation/internal/node.go
@@ -27,6 +27,17 @@ func nodeRunCommand(ls labels.LabelSet, task string) string {
 	return fmt.Sprintf("%s run %s", nodePackageManager(ls), task)
 }
 
+const privateNodeInstructions = `echo "One cause for node package install failure is if you have private repositories that it can't reach
+One way to fix this for private npm packages:
+  1. Use the npm CLI's \"login\" command to create a token (usually saved in your user's \"~/.npmrc\" file)
+    For more info, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=set%20the%20%24npm_token%20environment%20variable%20in%20circleci
+  2. Add a NPM_TOKEN to an org context
+    For info on how to use contexts, see https://circleci.com/docs/contexts/
+  3. Add a .circleci/config.yml to your repository or use this config.yml as a starting template
+  4. Configure the jobs to use the context that includes NPM_TOKEN
+  5. Add a step to inject your NPM_TOKEN environment variable into npm before \"install-packages\"
+    For an example, see https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/#:~:text=the%20deploy%20job%20has%20several%20steps%20that%20run%20to%20authenticate%20with%20and%20publish%20to"`
+
 func nodeInitialSteps(ls labels.LabelSet) []config.Step {
 	steps := []config.Step{
 		checkoutStep(ls[labels.DepsNode]),
@@ -42,10 +53,19 @@ func nodeInitialSteps(ls labels.LabelSet) []config.Step {
 		}
 	}
 
-	steps = append(steps, config.Step{
-		Type:       config.OrbCommand,
-		Command:    "node/install-packages",
-		Parameters: installParams})
+	steps = append(steps,
+		config.Step{
+			Type:       config.OrbCommand,
+			Command:    "node/install-packages",
+			Parameters: installParams,
+		},
+		config.Step{
+			Type:    config.Run,
+			Name:    "Print node install help instructions",
+			Command: privateNodeInstructions,
+			When:    config.WhenTypeOnFail,
+		},
+	)
 
 	return steps
 }


### PR DESCRIPTION
![](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fmedia.giphy.com%2Fmedia%2Fl396BM0OLbZFvPQWI%2Fgiphy.gif&f=1&nofb=1&ipt=a0a131fdb4c7879ca013c4d8a9545a4578cde8008947d7c875d957a74424aeef&ipo=images)
_(luckily, these are all copies of the same text)_

Adds instructions for installing private npm packages to node projects when the inferred job fails

Has both generated & inferconfig testing. Additionally, I created a [web-ui-insights test branch](https://github.com/circleci/web-ui-insights/compare/test/CVL-620/inferTest-1?expand=1) that shows this working (diff is super ugly, looking at it commit-by-commit will be much more clear). There, I've removed the original CircleCI Config, replaced it with a newly inferred config (from running the binary locally), & run it. The [job output shows this failing](https://app.circleci.com/pipelines/github/circleci/web-ui-insights/16786/workflows/3d04a2b6-be32-4260-b1b3-d025688acfe3/jobs/113698?invite=true#step-106-0_98_), as expected, & outputting the correct text to explain how to get private packages.