### PR TITLE
detect and tag empty repos

### DIFF
--- a/cmd/inferconfig/inferconfig_test.go
+++ b/cmd/inferconfig/inferconfig_test.go
@@ -30,7 +30,7 @@ func TestInferConfig(t *testing.T) {
 		{url: "https://github.com/CircleCI-Public/circleci-demo-ruby-rails"},
 		{url: "https://github.com/CircleCI-Public/circleci-demo-java-spring"},
 		// There is no "demo" for rust or maven, but the orbs repo contain sample dirs
-		{url: "https://github.com/CircleCI-Public/rust-orb"},
+		{url: "https://github.com/CircleCI-Public/rust-orb", branch: "main"},
 		{url: "https://github.com/CircleCI-Public/maven-orb", branch: "main"},
 		{url: "https://github.com/CircleCI-Public/sample-php-laravel", branch: "circleci-2.0"},
 	}

--- a/generation/generation_test.go
+++ b/generation/generation_test.go
@@ -1210,6 +1210,63 @@ workflows:
     #       - test-go
 `,
 		},
+		{
+			testName: "empty repo",
+			labels: labels.LabelSet{
+				labels.EmptyRepo: labels.Label{
+					Key:   labels.EmptyRepo,
+					Valid: true,
+				},
+			},
+			expected: `# Couldn't automatically generate a config from your source code.
+# This is a generic template to serve as a base for your custom config
+# See: https://circleci.com/docs/configuration-reference
+# Stacks detected: cicd:empty:
+version: 2.1
+jobs:
+  test:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      # Replace this with a real test runner invocation
+      - run:
+          name: Run tests
+          command: echo 'replace me with real tests!' && false
+  build:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - checkout
+      # Replace this with steps to build a package, or executable
+      - run:
+          name: Build an artifact
+          command: touch example.txt
+      - store_artifacts:
+          path: example.txt
+  deploy:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      # Replace this with steps to deploy to users
+      - run:
+          name: deploy
+          command: '#e.g. ./deploy.sh'
+      - run:
+          name: found empty repo
+          command: ':'
+workflows:
+  example:
+    jobs:
+      - test
+      - build:
+          requires:
+            - test
+      - deploy:
+          requires:
+            - test
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {

--- a/generation/internal/jobs.go
+++ b/generation/internal/jobs.go
@@ -53,6 +53,9 @@ func buildDeployJob(ls labels.LabelSet) *Job {
 	deployJob := stubDeployJob
 	deployJob.Steps = stubDeployJob.Steps
 	deployJob.Steps = append(deployJob.Steps, getCICDSteps(ls)...)
+	if emptyRepoLabel, ok := ls[labels.EmptyRepo]; ok && emptyRepoLabel.Valid {
+		deployJob.Steps = append(deployJob.Steps, getEmptyJobSteps(ls)...)
+	}
 
 	return &deployJob
 }
@@ -215,4 +218,14 @@ func getJobsByType(jobs []*Job) map[Type][]*config.Job {
 	}
 
 	return jobsByType
+}
+
+func getEmptyJobSteps(ls labels.LabelSet) []config.Step {
+	steps := make([]config.Step, 0)
+	steps = append(steps, config.Step{
+		Type:    config.Run,
+		Name:    "found empty repo",
+		Command: ":", // dont do anything just return status 0 and continue
+	})
+	return steps
 }

--- a/labeling/internal/empty.go
+++ b/labeling/internal/empty.go
@@ -1,0 +1,24 @@
+package internal
+
+import (
+	"github.com/CircleCI-Public/circleci-config/labeling/codebase"
+	"github.com/CircleCI-Public/circleci-config/labeling/labels"
+)
+
+var EmptyRepoRules = []labels.Rule{
+	func(c codebase.Codebase, ls labels.LabelSet) (label labels.Label, err error) {
+		label.Key = labels.EmptyRepo
+		_, err = c.FindFileMatching(func(path string) bool {
+			if path != "." {
+				return true
+			}
+			return false
+		}, "*")
+
+		if err == codebase.NotFoundError {
+			label.Valid = true
+			return label, nil
+		}
+		return label, err
+	},
+}

--- a/labeling/labeling.go
+++ b/labeling/labeling.go
@@ -38,6 +38,7 @@ func ApplyAllRules(c codebase.Codebase) labels.LabelSet {
 		internal.GithubActionRules,
 		internal.GitlabWorkflowRules,
 		internal.JenkinsRules,
+		internal.EmptyRepoRules,
 		// Add other stacks here
 	}
 

--- a/labeling/labeling_test.go
+++ b/labeling/labeling_test.go
@@ -854,3 +854,25 @@ func TestCodebase_ApplyRules_CICD(t *testing.T) {
 	}
 
 }
+
+func TestCodebase_ApplyRules_Empty(t *testing.T) {
+	repo := map[string]string{}
+	rules := internal.EmptyRepoRules
+
+	c := fakeCodebase{repo}
+	got := ApplyRules(c, rules)
+	want := labels.LabelSet{
+		labels.EmptyRepo: labels.Label{
+			Key:   labels.EmptyRepo,
+			Valid: true,
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("\n"+
+			"got        %+v\n"+
+			"expected   %+v\n", got, want,
+		)
+	}
+
+}

--- a/labeling/labels/labels.go
+++ b/labeling/labels/labels.go
@@ -25,6 +25,7 @@ const (
 	CICDGithubActions     = "cicd:github-actions"
 	CICDGitlabWorkflow    = "cicd:gitlab-workflows"
 	CICDJenkins           = "cicd:jenkins"
+	EmptyRepo             = "cicd:empty"
 	TestJest              = "test:jest"
 	ToolGradle            = "tool:gradle"
 	FileManagePy          = "file:manage.py"


### PR DESCRIPTION
Added logic to detect when a repo is empty and tag empty repos . The logic includes the following:
- New labeling `EmptyRepo`
- New stub step in the deploy job to help with the tagging.