### PR TITLE
CVL-1047: make sure to ignore .git directory for the empty label

### DIFF
--- a/labeling/internal/empty.go
+++ b/labeling/internal/empty.go
@@ -8,15 +8,18 @@ import (
 	"github.com/CircleCI-Public/circleci-config/labeling/labels"
 )
 
+var ignoreList = []string{
+	".",
+	"readme.md",
+	".git",
+}
+
 var EmptyRepoRules = []labels.Rule{
 	func(c codebase.Codebase, ls labels.LabelSet) (label labels.Label, err error) {
 		label.Key = labels.EmptyRepo
 		_, err = c.FindFileMatching(func(path string) bool {
-			if path == "." || strings.TrimSpace(strings.ToLower(path)) == "readme.md" {
-				return false
-			}
-
-			return true
+			path = strings.TrimSpace(strings.ToLower(path))
+			return !shouldIgnorePath(path)
 		}, "*")
 
 		if errors.Is(err, codebase.NotFoundError) {
@@ -25,4 +28,14 @@ var EmptyRepoRules = []labels.Rule{
 		}
 		return label, err
 	},
+}
+
+func shouldIgnorePath(path string) bool {
+	for _, token := range ignoreList {
+		if path == token {
+			return true
+		}
+	}
+
+	return strings.HasPrefix(path, ".git/")
 }

--- a/labeling/labeling_test.go
+++ b/labeling/labeling_test.go
@@ -878,7 +878,7 @@ func TestCodebase_ApplyRules_Empty(t *testing.T) {
 	})
 
 	t.Run("only has readme", func(t *testing.T) {
-		repo := map[string]string{"README.md": "#hello world"}
+		repo := map[string]string{"README.md": "#hello world", ".git/refs/ref1": "something", ".git": "something"}
 		rules := internal.EmptyRepoRules
 		c := fakeCodebase{repo}
 		got := ApplyRules(c, rules)
@@ -917,4 +917,5 @@ func TestCodebase_ApplyRules_Empty(t *testing.T) {
 		}
 
 	})
+
 }


### PR DESCRIPTION
Previously the `EmptyRepoRule` was failing on the hidden `.git` directory, this PR fixes it such that it will ignore any file in that directory along with the readme file.